### PR TITLE
Blizzard config adjustments

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -53,7 +53,7 @@ local function RefreshConfig()
   x:UpdateItemTypes()
 
   -- Update combat text engine CVars
-  x.cvar_udpate( true )
+  x.cvar_update( true )
     
   collectgarbage()
 end
@@ -107,7 +107,7 @@ function x:OnInitialize()
   x.GenerateColorOptions()
   
   -- Update combat text engine CVars
-  x.cvar_udpate()
+  x.cvar_update()
   
   -- Everything got Initialized, show Startup Text
   if self.db.profile.showStartupText then

--- a/modules/blizzard.lua
+++ b/modules/blizzard.lua
@@ -24,17 +24,20 @@ hooksecurefunc('CombatText_AddMessage', function(message, scrollFunction, r, g, 
   x:AddMessage("general", message, {r, g, b})
 end)
 
-local fsTitle, configButton
-InterfaceOptionsCombatTextPanel:HookScript('OnShow', function(self)
+hooksecurefunc(InterfaceOptionsCombatTextPanel, 'refresh', function(...)
+  -- @see InterfaceOptionsPanel_Refresh
+  local self = InterfaceOptionsCombatTextPanel
   for _, control in pairs(self.controls) do
-    -- UIFrameFadeOut(control, 0, 0, 0)
     if control.type == CONTROLTYPE_DROPDOWN then
-    	UIDropDownMenu_DisableDropDown(control)
+      UIDropDownMenu_DisableDropDown(control)
     else
       control:Disable()
     end
   end
+end)
 
+local fsTitle, configButton
+InterfaceOptionsCombatTextPanel:HookScript('OnShow', function(self)
   if not fsTitle then
     -- Show Combat Options Title
     fsTitle = self:CreateFontString(nil, "OVERLAY")

--- a/modules/blizzard.lua
+++ b/modules/blizzard.lua
@@ -9,7 +9,7 @@
  [=====================================]
  [  Author: Dandraffbal-Stormreaver US ]
  [  xCT+ Version 4.x.x                 ]
- [  ©2015. All Rights Reserved.        ]
+ [  Â©2015. All Rights Reserved.        ]
  [====================================]]
  
 local ADDON_NAME, addon = ...
@@ -24,57 +24,43 @@ hooksecurefunc('CombatText_AddMessage', function(message, scrollFunction, r, g, 
   x:AddMessage("general", message, {r, g, b})
 end)
 
--- Move the options up
-local defaultFont, defaultSize = InterfaceOptionsCombatTextPanelTargetEffectsText:GetFont()
+local fsTitle, configButton
+InterfaceOptionsCombatTextPanel:HookScript('OnShow', function(self)
+  for _, control in pairs(self.controls) do
+    -- UIFrameFadeOut(control, 0, 0, 0)
+    if control.type == CONTROLTYPE_DROPDOWN then
+      _G[control:GetName()..'Button']:Disable()
+    else
+      control:Disable()
+    end
+  end
 
--- Show Combat Options Title
-local fsTitle = InterfaceOptionsCombatTextPanel:CreateFontString(nil, "OVERLAY")
-fsTitle:SetTextColor(1.00, 1.00, 1.00, 1.00)
-fsTitle:SetFont(defaultFont, defaultSize)
-fsTitle:SetText("|cff60A0FFPowered By |cffFF0000x|r|cff80F000CT|r+|r")
---fsTitle:SetPoint("TOPLEFT", 16, -90)
-fsTitle:SetPoint("TOPLEFT", 480, -16)
+  if not fsTitle then
+    -- Show Combat Options Title
+    fsTitle = self:CreateFontString(nil, "OVERLAY")
+    fsTitle:SetTextColor(1.00, 1.00, 1.00, 1.00)
+    fsTitle:SetFontObject(GameFontHighlightLeft)
+    fsTitle:SetText("|cff60A0FFPowered By |cffFF0000x|r|cff80F000CT|r+|r")
+    --fsTitle:SetPoint("TOPLEFT", 16, -90)
+    fsTitle:SetPoint("TOPLEFT", 480, -16)
+  end
 
--- Move the Effects and Floating Options
---[[InterfaceOptionsCombatTextPanelTargetEffects:ClearAllPoints()
-InterfaceOptionsCombatTextPanelTargetEffects:SetPoint("TOPLEFT", 314, -132)
-InterfaceOptionsCombatTextPanelEnableFCT:ClearAllPoints()
-InterfaceOptionsCombatTextPanelEnableFCT:SetPoint("TOPLEFT", 18, -132)
-
-InterfaceOptionsCombatTextPanelTargetDamage:ClearAllPoints()
-InterfaceOptionsCombatTextPanelTargetDamage:SetPoint("TOPLEFT", 18, -355) ]]
-
--- Hide Blizzard Pet Battle Options
-InterfaceOptionsCombatTextPanelPetBattle:Hide()
-
--- Hide Blizzard Combat Text Toggles
-InterfaceOptionsCombatTextPanelEnableFCT:Hide()
-InterfaceOptionsCombatTextPanelTargetEffects:Hide()
-InterfaceOptionsCombatTextPanelOtherTargetEffects:Hide()
-InterfaceOptionsCombatTextPanelDodgeParryMiss:Hide()
-InterfaceOptionsCombatTextPanelDamageReduction:Hide()
-InterfaceOptionsCombatTextPanelRepChanges:Hide()
-InterfaceOptionsCombatTextPanelReactiveAbilities:Hide()
-InterfaceOptionsCombatTextPanelFriendlyHealerNames:Hide()
-InterfaceOptionsCombatTextPanelCombatState:Hide()
-InterfaceOptionsCombatTextPanelComboPoints:Hide()
-InterfaceOptionsCombatTextPanelLowManaHealth:Hide()
-InterfaceOptionsCombatTextPanelEnergyGains:Hide()
-InterfaceOptionsCombatTextPanelPeriodicEnergyGains:Hide()
-InterfaceOptionsCombatTextPanelHonorGains:Hide()
-InterfaceOptionsCombatTextPanelAuras:Hide()
-InterfaceOptionsCombatTextPanelHealingAbsorbSelf:Hide()
-
--- Direction does NOT work with xCT+ at all
-InterfaceOptionsCombatTextPanelFCTDropDown:Hide()
-InterfaceOptionsCombatTextPanelTargetModeDropDown:Hide()
-
--- FCT Options
-InterfaceOptionsCombatTextPanelTargetDamage:Hide()
-InterfaceOptionsCombatTextPanelPeriodicDamage:Hide()
-InterfaceOptionsCombatTextPanelPetDamage:Hide()
-InterfaceOptionsCombatTextPanelHealing:Hide()
-InterfaceOptionsCombatTextPanelHealingAbsorbTarget:Hide()
+  if not configButton then
+    -- Create a button to delete profiles
+    configButton = CreateFrame("Button", nil, self, "UIPanelButtonTemplate")
+    configButton:ClearAllPoints()
+    configButton:SetPoint("TOPRIGHT", -36, -80)
+    configButton:SetSize(200, 30)
+    configButton:SetText("|cffFFFFFFOpen |r|cffFF0000x|r|cff80F000CT|r|cff60A0FF+|r |cffFFFFFFOptions...|r")
+    configButton:Show()
+    configButton:SetScript("OnClick", function(self)
+      InterfaceOptionsFrame_OnHide()
+      HideUIPanel(GameMenuFrame)
+      --LibStub("AceConfigDialog-3.0"):Open(ADDON_NAME)
+      x:ShowConfigTool()
+    end)
+  end
+end)
 
 function x:UpdateBlizzardFCT()
   if self.db.profile.blizzardFCT.enabled then

--- a/modules/blizzard.lua
+++ b/modules/blizzard.lua
@@ -79,24 +79,6 @@ CombatText:SetScript("OnLoad", nil)
 CombatText:SetScript("OnEvent", nil)
 CombatText:SetScript("OnUpdate", nil)
 
-
--- Create a button to delete profiles
-if not xCTCombatTextConfigButton then
-  CreateFrame("Button", "xCTCombatTextConfigButton", InterfaceOptionsCombatTextPanel, "UIPanelButtonTemplate")
-end
-
-xCTCombatTextConfigButton:ClearAllPoints()
-xCTCombatTextConfigButton:SetPoint("TOPRIGHT", -36, -80)
-xCTCombatTextConfigButton:SetSize(200, 30)
-xCTCombatTextConfigButton:SetText("|cffFFFFFFOpen |r|cffFF0000x|r|cff80F000CT|r|cff60A0FF+|r |cffFFFFFFOptions...|r")
-xCTCombatTextConfigButton:Show()
-xCTCombatTextConfigButton:SetScript("OnClick", function(self)
-  InterfaceOptionsFrameOkay:Click()
-  GameMenuButtonContinue:Click()
-  --LibStub("AceConfigDialog-3.0"):Open(ADDON_NAME)
-  x:ShowConfigTool()
-end)
-
 -- Interface - Addons (Ace3 Blizzard Options)
 x.blizzardOptions = {
   name = "|cffFFFF00Combat Text - |r|cff60A0FFPowered By |cffFF0000x|r|cff80F000CT|r+|r",
@@ -107,7 +89,7 @@ x.blizzardOptions = {
       order = 1,
       type = 'execute',
       name = "Show Config",
-      func = function() InterfaceOptionsFrameOkay:Click(); GameMenuButtonContinue:Click(); x:ShowConfigTool() end,
+      func = function() InterfaceOptionsFrame_OnHide(); HideUIPanel(GameMenuFrame); x:ShowConfigTool() end,
     },
   },
 }

--- a/modules/blizzard.lua
+++ b/modules/blizzard.lua
@@ -29,7 +29,7 @@ InterfaceOptionsCombatTextPanel:HookScript('OnShow', function(self)
   for _, control in pairs(self.controls) do
     -- UIFrameFadeOut(control, 0, 0, 0)
     if control.type == CONTROLTYPE_DROPDOWN then
-      _G[control:GetName()..'Button']:Disable()
+    	UIDropDownMenu_DisableDropDown(control)
     else
       control:Disable()
     end

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -9,7 +9,7 @@
  [=====================================]
  [  Author: Dandraffbal-Stormreaver US ]
  [  xCT+ Version 4.x.x                 ]
- [  ©2015. All Rights Reserved.        ]
+ [  Â©2015. All Rights Reserved.        ]
  [====================================]]
  
 local ADDON_NAME, addon = ...
@@ -143,18 +143,18 @@ addon.options = {
 -- A fast C-Var Update routine
 local function isCVarsDisabled( ) return x.db.profile.bypassCVars end
 
-x.cvar_udpate = function( force )
+x.cvar_update = function( force )
   -- Always have Combat Text Enabled
   SetCVar("enableCombatText", 1)
-  _G["SHOW_COMBAT_TEXT"] = "1"
-  
--- Floating Combat Text: Threat Changes
-  if x.db.profile.blizzardFCT.CombatThreatChanges then
-    COMBAT_THREAT_DECREASE_0, COMBAT_THREAT_DECREASE_1, COMBAT_THREAT_DECREASE_2 = XCT_CT_DEC_0, XCT_CT_DEC_1, XCT_CT_DEC_2
-    COMBAT_THREAT_INCREASE_1, COMBAT_THREAT_INCREASE_3 = XCT_CT_INC_1, XCT_CT_INC_3
-  else
+
+  -- Floating Combat Text: Threat Changes
+  if not x.db.profile.blizzardFCT.CombatThreatChanges then
     COMBAT_THREAT_DECREASE_0, COMBAT_THREAT_DECREASE_1, COMBAT_THREAT_DECREASE_2 = "", "", ""
     COMBAT_THREAT_INCREASE_1, COMBAT_THREAT_INCREASE_3 = "", ""
+  elseif COMBAT_THREAT_DECREASE_0 == "" then
+    -- only overwrite Blizzard constants if they were previously changed
+    COMBAT_THREAT_DECREASE_0, COMBAT_THREAT_DECREASE_1, COMBAT_THREAT_DECREASE_2 = XCT_CT_DEC_0, XCT_CT_DEC_1, XCT_CT_DEC_2
+    COMBAT_THREAT_INCREASE_1, COMBAT_THREAT_INCREASE_3 = XCT_CT_INC_1, XCT_CT_INC_3
   end
 
   if  isCVarsDisabled( ) then
@@ -166,196 +166,166 @@ x.cvar_udpate = function( force )
   end
 
   -- We dont care about "combatTextFloatMode"
-  -- _G["COMBAT_TEXT_FLOAT_MODE"] = "1"
 
   -- Check: fctLowManaHealth (General Option)
   if x.db.profile.frames.general.showLowManaHealth then
     SetCVar("fctLowManaHealth", 1)
-    _G["COMBAT_TEXT_SHOW_LOW_HEALTH_MANA"] = "1"
   else
     SetCVar("fctLowManaHealth", 0)
-    _G["COMBAT_TEXT_SHOW_LOW_HEALTH_MANA"] = "0"
   end
-  
+
   -- Check: fctAuras (General Option)
   if x.db.profile.frames.general.showBuffs or x.db.profile.frames.general.showDebuffs then
     SetCVar("fctAuras", 1)
-    _G["COMBAT_TEXT_SHOW_AURAS"] = "1"
-    _G["COMBAT_TEXT_SHOW_AURA_FADE"] = "1"
   else
     SetCVar("fctAuras", 0)
-    _G["COMBAT_TEXT_SHOW_AURAS"] = "0"
-    _G["COMBAT_TEXT_SHOW_AURA_FADE"] = "0"
   end
-  
+
   -- Check: fctCombatState (General Option)
   if x.db.profile.frames.general.showCombatState then
     SetCVar("fctCombatState", 1)
-    _G["COMBAT_TEXT_SHOW_COMBAT_STATE"] = "1"
   else
     SetCVar("fctCombatState", 0)
-    _G["COMBAT_TEXT_SHOW_COMBAT_STATE"] = "0"
   end
-  
+
   -- Check: fctDodgeParryMiss (Damage Option)
   if x.db.profile.frames.damage.showDodgeParryMiss then
     SetCVar("fctDodgeParryMiss", 1)
-    _G["COMBAT_TEXT_SHOW_DODGE_PARRY_MISS"] = "1"
   else
     SetCVar("fctDodgeParryMiss", 0)
-    _G["COMBAT_TEXT_SHOW_DODGE_PARRY_MISS"] = "0"
   end
-  
+
   -- Check: fctDamageReduction (Damage Option)
   if x.db.profile.frames.damage.showDamageReduction then
     SetCVar("fctDamageReduction", 1)
-    _G["COMBAT_TEXT_SHOW_RESISTANCES"] = "1"
   else
     SetCVar("fctDamageReduction", 0)
-    _G["COMBAT_TEXT_SHOW_RESISTANCES"] = "0"
   end
-  
+
   -- Check: fctRepChanges (General Option)
   if x.db.profile.frames.general.showRepChanges then
     SetCVar("fctRepChanges", 1)
-    _G["COMBAT_TEXT_SHOW_REPUTATION"] = "1"
   else
     SetCVar("fctRepChanges", 0)
-    _G["COMBAT_TEXT_SHOW_REPUTATION"] = "0"
   end
-  
+
   -- Check: fctHonorGains (General Option)
   if x.db.profile.frames.damage.showHonorGains then
     SetCVar("fctHonorGains", 1)
-    _G["COMBAT_TEXT_SHOW_HONOR_GAINED"] = "1"
   else
     SetCVar("fctHonorGains", 0)
-    _G["COMBAT_TEXT_SHOW_HONOR_GAINED"] = "0"
   end
-  
+
   -- Check: fctReactives (Attach to Procs Frame)
   if x.db.profile.frames.procs.enabledFrame then
     SetCVar("fctReactives", 1)
-    _G["COMBAT_TEXT_SHOW_REACTIVES"] = "1"
   else
     SetCVar("fctReactives", 0)
-    _G["COMBAT_TEXT_SHOW_REACTIVES"] = "0"
   end
-  
+
   -- Check: fctFriendlyHealers (Healing Option)
   if x.db.profile.frames.healing.showFriendlyHealers then
     SetCVar("fctFriendlyHealers", 1)
-    _G["COMBAT_TEXT_SHOW_FRIENDLY_NAMES"] = "1"
   else
     SetCVar("fctFriendlyHealers", 0)
-    _G["COMBAT_TEXT_SHOW_FRIENDLY_NAMES"] = "0"
   end
-  
+
   -- Check: CombatHealingAbsorbSelf (Healing Option)
   if x.db.profile.frames.healing.enableSelfAbsorbs then
     SetCVar("CombatHealingAbsorbSelf", 1)
-    _G["SHOW_COMBAT_HEALING_ABSORB_SELF"] = "1"
   else
     SetCVar("CombatHealingAbsorbSelf", 0)
-    _G["SHOW_COMBAT_HEALING_ABSORB_SELF"] = "0"
   end
-  
+
   -- Check: fctComboPoints (COMBO Option)
   if x.player.class == "ROGUE" and x.db.profile.frames.class.enabledFrame then
     SetCVar("fctComboPoints", 1)
-    _G["COMBAT_TEXT_SHOW_COMBO_POINTS"] = "1"
   else
     SetCVar("fctComboPoints", 0)
-    _G["COMBAT_TEXT_SHOW_COMBO_POINTS"] = "0"
   end
-  
+
   -- Check: fctEnergyGains (Power Option)
   if x.db.profile.frames.power.showEnergyGains then
     SetCVar("fctEnergyGains", 1)
-    _G["COMBAT_TEXT_SHOW_ENERGIZE"] = "1"
   else
     SetCVar("fctEnergyGains", 0)
-    _G["COMBAT_TEXT_SHOW_ENERGIZE"] = "0"
   end
-  
+
   -- Check: fctPeriodicEnergyGains (Power Option)
   if x.db.profile.frames.power.showPeriodicEnergyGains then
     SetCVar("fctPeriodicEnergyGains", 1)
-    _G["COMBAT_TEXT_SHOW_PERIODIC_ENERGIZE"] = "1"
   else
     SetCVar("fctPeriodicEnergyGains", 0)
-    _G["COMBAT_TEXT_SHOW_PERIODIC_ENERGIZE"] = "0"
   end
-  
+
   -- Floating Combat Text: Effects
   if x.db.profile.blizzardFCT.fctSpellMechanics then
     SetCVar("fctSpellMechanics", 1)
   else
     SetCVar("fctSpellMechanics", 0)
   end
-  
+
   -- Floating Combat Text: Effects (Others)
   if x.db.profile.blizzardFCT.fctSpellMechanicsOther then
     SetCVar("fctSpellMechanicsOther", 1)
   else
     SetCVar("fctSpellMechanicsOther", 0)
   end
-  
+
   -- Floating Combat Text: Outgoing Damage
   if x.db.profile.blizzardFCT.CombatDamage then
     SetCVar("CombatDamage", 1)
   else
     SetCVar("CombatDamage", 0)
   end
-  
+
   -- Floating Combat Text: Outgoing Dots and Hots
   if x.db.profile.blizzardFCT.CombatLogPeriodicSpells then
     SetCVar("CombatLogPeriodicSpells", 1)
   else
     SetCVar("CombatLogPeriodicSpells", 0)
   end
-  
+
   -- Floating Combat Text: Outgoing Pet Damage
   if x.db.profile.blizzardFCT.PetMeleeDamage then
     SetCVar("PetMeleeDamage", 1)
   else
     SetCVar("PetMeleeDamage", 0)
   end
-  
+
   -- Floating Combat Text: Outgoing Healing
   if x.db.profile.blizzardFCT.CombatHealing then
     SetCVar("CombatHealing", 1)
   else
     SetCVar("CombatHealing", 0)
   end
-  
+
   -- Floating Combat Text: Outgoing Absorbs
   if x.db.profile.blizzardFCT.CombatHealingAbsorbTarget then
     SetCVar("CombatHealingAbsorbTarget", 1)
   else
     SetCVar("CombatHealingAbsorbTarget", 0)
   end
-  
+
   -- Floating Combat Text: Display Target Mode
   SetCVar("CombatDamageStyle", x.db.profile.blizzardFCT.CombatDamageStyle)
-  
 end
 
 -- Generic Get/Set methods
 local function get0(info) return x.db.profile[info[#info-1]][info[#info]] end
-local function set0(info, value) x.db.profile[info[#info-1]][info[#info]] = value; x.cvar_udpate() end
-local function set0_update(info, value) x.db.profile[info[#info-1]][info[#info]] = value; x:UpdateFrames(); x.cvar_udpate() end
+local function set0(info, value) x.db.profile[info[#info-1]][info[#info]] = value; x.cvar_update() end
+local function set0_update(info, value) x.db.profile[info[#info-1]][info[#info]] = value; x:UpdateFrames(); x.cvar_update() end
 local function get0_1(info) return x.db.profile[info[#info-2]][info[#info]] end
-local function set0_1(info, value) x.db.profile[info[#info-2]][info[#info]] = value; x.cvar_udpate() end
+local function set0_1(info, value) x.db.profile[info[#info-2]][info[#info]] = value; x.cvar_update() end
 local function getTextIn0(info) return string_gsub(x.db.profile[info[#info-1]][info[#info]], "|", "||") end
-local function setTextIn0(info, value) x.db.profile[info[#info-1]][info[#info]] = string_gsub(value, "||", "|"); x.cvar_udpate() end
+local function setTextIn0(info, value) x.db.profile[info[#info-1]][info[#info]] = string_gsub(value, "||", "|"); x.cvar_update() end
 local function get1(info) return x.db.profile.frames[info[#info-1]][info[#info]] end
-local function set1(info, value) x.db.profile.frames[info[#info-1]][info[#info]] = value; x.cvar_udpate() end
-local function set1_update(info, value) set1(info, value); x:UpdateFrames(info[#info-1]); x.cvar_udpate() end
+local function set1(info, value) x.db.profile.frames[info[#info-1]][info[#info]] = value; x.cvar_update() end
+local function set1_update(info, value) set1(info, value); x:UpdateFrames(info[#info-1]); x.cvar_update() end
 local function get2(info) return x.db.profile.frames[info[#info-2]][info[#info]] end
-local function set2(info, value) x.db.profile.frames[info[#info-2]][info[#info]] = value; x.cvar_udpate() end
-local function set2_update(info, value) set2(info, value); x:UpdateFrames(info[#info-2]); x.cvar_udpate() end
-local function set2_update_force(info, value) set2(info, value); x:UpdateFrames(info[#info-2]); x.cvar_udpate(true) end
+local function set2(info, value) x.db.profile.frames[info[#info-2]][info[#info]] = value; x.cvar_update() end
+local function set2_update(info, value) set2(info, value); x:UpdateFrames(info[#info-2]); x.cvar_update() end
+local function set2_update_force(info, value) set2(info, value); x:UpdateFrames(info[#info-2]); x.cvar_update(true) end
 local function getColor2(info) return unpack(x.db.profile.frames[info[#info-2]][info[#info]] or blankTable) end
 local function setColor2(info, r, g, b) x.db.profile.frames[info[#info-2]][info[#info]] = {r,g,b} end
 local function getTextIn2(info) return string_gsub(x.db.profile.frames[info[#info-2]][info[#info]], "|", "||") end
@@ -1442,7 +1412,7 @@ addon.options.args["FloatingCombatText"] = {
             x.db.profile.blizzardFCT.fontName = LSM:Fetch("font", value)
             
             --x:UpdateFrames()
-            --x.cvar_udpate()
+            --x.cvar_update()
           end,
           disabled = function(info) return isCVarsDisabled( ) or not x.db.profile.blizzardFCT.enabled end,
         },


### PR DESCRIPTION
Hey dandruff,

I figured we didn't need to alter the Blizzard config right away, without it even being shown. Therefore I moved this into a wrapper function that gets called on the panel's OnShow. Might mean the code runs multiple times, but then, the config is always meant to be disabled with xCT loaded and the frames are only created once.
This also helped be reduce taints since once you even glance at an UIDropDown, the whole UI goes crazy. Delaying this involvement did help in my case, since if you don't open the panel, there are no changes made :)

Regarding "disabled": I personally don't like not seeing anything in that tab. So I simply disabled the controls instead of hiding them. This brings the added bonus that the code does not need to be updated whenever Blizzard adds a new setting to the panel.

![bildschirmfoto 2015-04-09 um 10 05 27](https://cloud.githubusercontent.com/assets/151904/7062956/95b1a9ca-dea2-11e4-84e1-8c0d4594da5c.png)
