### PR TITLE
Fix unit buff error and incorrect value

### DIFF
--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1203,6 +1203,7 @@ local CombatEventHandlers = {
 	["ShieldOutgoing"] = function (args)
 		local buffIndex = x.findBuffIndex(args.destName, args.spellName)
 		if not buffindex then return end
+		local settings, value = x.db.profile.frames['outgoing'], select(16, UnitBuff(args.destName, buffIndex))
 		if not value or value <= 0 then return end
 
 		-- Keep track of spells that go by
@@ -1504,6 +1505,7 @@ local CombatEventHandlers = {
 	["ShieldIncoming"] = function (args)
 		local buffIndex = x.findBuffIndex("player", args.spellName)
 		if not buffIndex then return end
+		local settings, value = x.db.profile.frames['healing'], select(16, UnitBuff("player", buffIndex))
 		if not value or value <= 0 then return end
 
 		if TrackSpells() then x.spellCache.healing[args.spellId] = true end

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1202,8 +1202,7 @@ end
 local CombatEventHandlers = {
 	["ShieldOutgoing"] = function (args)
 		local buffIndex = x.findBuffIndex(args.destName, args.spellName)
-		local settings, value = x.db.profile.frames['outgoing'], select(17, UnitBuff(args.destName, buffIndex))
-		--local settings, value = x.db.profile.frames['outgoing'], select(17, UnitBuff(args.destName, args.spellName))
+		if not buffindex then return end
 		if not value or value <= 0 then return end
 
 		-- Keep track of spells that go by
@@ -1504,8 +1503,7 @@ local CombatEventHandlers = {
 
 	["ShieldIncoming"] = function (args)
 		local buffIndex = x.findBuffIndex("player", args.spellName)
-		local settings, value = x.db.profile.frames['healing'], select(17, UnitBuff("player", buffIndex))
-		--local settings, value = x.db.profile.frames['healing'], select(17, UnitBuff("player", args.spellName))
+		if not buffIndex then return end
 		if not value or value <= 0 then return end
 
 		if TrackSpells() then x.spellCache.healing[args.spellId] = true end
@@ -1884,9 +1882,9 @@ function x.CombatLogEvent (args)
 	end
 end
 
-function x.findBuffIndex(unitId, spellName)
+function x.findBuffIndex(unitName, spellName)
 	for i = 1, 40 do
-		buffName, _, _, _, _, _, _, _, _ , spellId, _, _, _, _ = UnitBuff(unitId, i)
+		buffName, _, _, _, _, _, _, _, _ , spellId, _, _, _, _ = UnitBuff(unitName, i)
 		if buffName == spellName then
 			return i
 		end


### PR DESCRIPTION
Resolve issue that came up with casting PW:S on a non-party member target, where buffIndex would return nil and result in an error on the subsequent UnitBuff call.

Also change the select call to 16 instead of 17, with the removal of one of the returned parameters from UnitBuff.