### PR TITLE
Fix justify=left for merged spam.

### DIFF
--- a/modules/frames.lua
+++ b/modules/frames.lua
@@ -636,8 +636,8 @@ do
 				message = x:GetSpellTextureFormatted( stack[idIndex],
 				                                  message,
 				                                  settings.iconsEnabled and settings.iconsSize or -1,
-				                                  settings.fontJustify,
 				                                  settings.spacerIconsEnabled,
+				                                  settings.fontJustify,
 				                                  strColor,
 				                                  true, -- Merge Override = true
 				                                  #item.entries )
@@ -645,8 +645,8 @@ do
 				message = x:GetSpellTextureFormatted( stack[idIndex],
 				                                  message,
 				                                  settings.iconsEnabled and settings.iconsSize or -1,
-				                                  settings.fontJustify,
 				                                  settings.spacerIconsEnabled,
+				                                  settings.fontJustify,
 				                                  strColor,
 				                                  true, -- Merge Override = true
 				                                  #item.entries )


### PR DESCRIPTION
Fixes dandruff/xCT#182.
In dandruff/xCT@69c02e42bfe4d2366a92484b91d42ac4b9e6c8a1 (dandruff/xCT#170) the `spacerIconsEnabled` option was added at the wrong index and thus the options for `fontJustify` and `spacerIconsEnabled` was swapped, causing check for `LEFT` to fail and always fallback to code for RIGHT.