### PR TITLE
Some merging improvements

### DIFF
--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -338,6 +338,7 @@ do
 	spell '115175' '1.5' --  Soothing Mist
 	spell '124682' '1.5' --  Eneloping Mist
 	spell '191840' '1.5' --  Essence Font
+	alias '344006' '191840' -- Essence Font (Faeline Stomp)
 	spell '119611' '2.0' --  Renewing Mists
 	spell '115310' '0.5' --  Revival
 	spell '116670' '0.5' --  Vivify

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -315,8 +315,6 @@ do
 	spell '115181' '0.5' --  Breath of Fire
 	spell '123725' '2.5' --  Breath of Fire (DoT)
 	spell '121253' '0.5' --  Keg Smash
-	spell '130654' '1.5' --  Chi Burst (Healing)
-	spell '130654' '1.5' --  Chi Burst (Damage)
 	spell '227291' '0.5' --  Talent: Niuzao, The Black Ox (Stomp)
 	spell '196733' '0.5' --  Talent: Special Delivery
 	spell '214326' '0.5' --  Artifact: Exploding Keg

--- a/config/merge_shadowlands.lua
+++ b/config/merge_shadowlands.lua
@@ -18,7 +18,7 @@ local ADDON_NAME, addon = ...
 -- 'alias' takes the original spell id and a replacement spell id
 -- item takes a item id, the merge interval in seconds, and a helpful description of the item
 -- header switches the header for the next set of items
-local _, _, _, alias, item, header = unpack(addon.merge_helpers)
+local spell, _, _, alias, item, header = unpack(addon.merge_helpers)
 
 --[[header "|cffd2d3d8SL|r™ |cff798BDDTemplates|r"
 do

--- a/config/merge_shadowlands.lua
+++ b/config/merge_shadowlands.lua
@@ -81,3 +81,7 @@ do
 	alias '344752' '336214' -- Eternal Call to the Void: Mind Sear
 end
 
+header "|cffd2d3d8ShadowLands|r™ |cff798BDDEnchants|r"
+do
+	item '324184' '1.5' "Lightless Force"
+end

--- a/config/merge_shadowlands.lua
+++ b/config/merge_shadowlands.lua
@@ -47,6 +47,11 @@ do
 	item '321792' '1.0' "Impending Catastrophe"
 	alias '322167' '321792' -- Impending Catastrophe dot
 	alias '322170' '321792' -- Impending Catastrophe dot
+
+	-- Night Fae
+	-- Monk
+	spell '327264' '0.5' -- Faeline Stomp (Damage)
+	spell '345727' '0.5' -- Faeline Stomp Heal / Windwalker Bonnus Damage
 end
 
 header "|cffd2d3d8ShadowLands|r™ |cff798BDDQuest Spells|r"


### PR DESCRIPTION
* Remove [Chi Burst](https://www.wowhead.com/spell=123986) duplicate from Brewmaster specialization. (https://github.com/dandruff/xCT/commit/cc7ffb9c8a63a53fe9ca8c2831df243f758e84a7)
  > It had the same ID twice by accident, and used the exact same ID as the "all specs" section. 
* Add merge for [Lightless Force](https://www.wowhead.com/item=172370) weapon enchant proc. (https://github.com/dandruff/xCT/commit/4feff9b60695455160d514b3c5917dd4dd216301)
* Add alias for "special" [Essence Font](https://www.wowhead.com/spell=191837) that is triggered when using [Faeline Stomp](https://www.wowhead.com/spell=327104) as Mistweaver.
* Add merge for [Faeline Stomp](https://www.wowhead.com/spell=327104).
  > However for *Windwalker* there will be a problem where the healing is merged with the bonus damage that their stomp does. Not sure if there's any way to merge them separately? Couldn't see anything looking at the configuration and code.