### PR TITLE
Add merging of incoming damage

### DIFF
--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1562,7 +1562,17 @@ local CombatEventHandlers = {
 			end
 		end
 
-		-- TODO: Add merge settings
+		local colorOverride
+		if args.spellSchool == 1 then
+			colorOverride = args.critical and 'damageTakenCritical' or 'damageTaken'
+		else
+			colorOverride = args.critical and 'spellDamageTakenCritical' or 'spellDamageTaken'
+		end
+
+		if IsMerged(args.spellId) then
+			x:AddSpamMessage('damage', args.spellId, args.amount, colorOverride)
+			return
+		end
 
 		-- Add names
 		message = message .. x.formatName(args, settings.names, true)
@@ -1580,13 +1590,6 @@ local CombatEventHandlers = {
 			       x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
 			       x.db.profile.frames['damage'].spacerIconsEnabled,
 			       x.db.profile.frames['damage'].fontJustify)
-		end
-
-		local colorOverride
-		if args.spellSchool == 1 then
-			colorOverride = args.critical and 'damageTakenCritical' or 'damageTaken'
-		else
-			colorOverride = args.critical and 'spellDamageTakenCritical' or 'spellDamageTaken'
 		end
 
 		-- Output message


### PR DESCRIPTION
This adds very basic merging of incoming damage. This is most relevant for brewmaster monks since they have "stagger" which ticks damage quickly. It works with stagger as it is now. 

I guess the current solution will also merge incoming damage that is merged, like from other players etc. That's maybe not expected.. Maybe should just do merging for damage where player is source?