### PR TITLE
Filtering spells even when they're misses

### DIFF
--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1749,6 +1749,9 @@ local CombatEventHandlers = {
 		if args.missType == "IMMUNE" and not ShowImmunes() then return end
 		if args.missType ~= "IMMUNE" and not ShowMisses() then return end
 
+		-- Check if spell is filtered
+		if IsSpellFiltered(spellId) then return end
+
 		-- Add Icons
 		message = x:GetSpellTextureFormatted(spellId,
 		                                     message,

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1777,25 +1777,6 @@ local CombatEventHandlers = {
 		x:AddMessage('damage', message, missTypeColorLookup[args.missType] or 'misstypesOut')
 	end,
 
-	["IncomingAbsorb"] = function (args)
-		if not ShowMissTypes() then return end
-
-		-- Check if spell is filtered
-		-- (This doesn't work since we don't have any spellId)
-		if IsDamageFiltered(args.extraSpellId) then return end
-
-		local message = _G["COMBAT_TEXT_ABSORB"]
-
-		-- Add Icons
-		message = x:GetSpellTextureFormatted(nil,
-		                                          message,
-		          x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
-		          x.db.profile.frames['damage'].spacerIconsEnabled,
-		          x.db.profile.frames['damage'].fontJustify)
-
-		x:AddMessage('damage', message, FULL_MISS_COLORS.absorbed or 'misstypesOut')
-	end,
-
 	["SpellDispel"] = function (args)
 		if not ShowDispells() then return end
 
@@ -1979,9 +1960,6 @@ function x.CombatLogEvent (args)
 
 		elseif args.suffix == "_MISSED" then
 			CombatEventHandlers.IncomingMiss(args)
-
-		elseif args.suffix == "_ABSORBED" then
-			CombatEventHandlers.IncomingAbsorb(args)
 
 		elseif args.event == 'SPELL_DISPEL' then
 			if ShowDispells() then

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1777,6 +1777,25 @@ local CombatEventHandlers = {
 		x:AddMessage('damage', message, missTypeColorLookup[args.missType] or 'misstypesOut')
 	end,
 
+	["IncomingAbsorb"] = function (args)
+		if not ShowMissTypes() then return end
+
+		-- Check if spell is filtered
+		-- (This doesn't work since we don't have any spellId)
+		if IsDamageFiltered(args.extraSpellId) then return end
+
+		local message = _G["COMBAT_TEXT_ABSORB"]
+
+		-- Add Icons
+		message = x:GetSpellTextureFormatted(nil,
+		                                          message,
+		          x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
+		          x.db.profile.frames['damage'].spacerIconsEnabled,
+		          x.db.profile.frames['damage'].fontJustify)
+
+		x:AddMessage('damage', message, FULL_MISS_COLORS.absorbed or 'misstypesOut')
+	end,
+
 	["SpellDispel"] = function (args)
 		if not ShowDispells() then return end
 
@@ -1960,6 +1979,9 @@ function x.CombatLogEvent (args)
 
 		elseif args.suffix == "_MISSED" then
 			CombatEventHandlers.IncomingMiss(args)
+
+		elseif args.suffix == "_ABSORBED" then
+			CombatEventHandlers.IncomingAbsorb(args)
 
 		elseif args.event == 'SPELL_DISPEL' then
 			if ShowDispells() then

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1775,7 +1775,7 @@ local CombatEventHandlers = {
 		local message = _G["COMBAT_TEXT_"..args.missType]
 
 		-- Add Icons
-		message = x:GetSpellTextureFormatted(args.extraSpellId,
+		message = x:GetSpellTextureFormatted(args.spellId,
 		                                          message,
 		          x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
 		          x.db.profile.frames['damage'].spacerIconsEnabled,

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1772,6 +1772,9 @@ local CombatEventHandlers = {
 	["IncomingMiss"] = function (args)
 		if not ShowMissTypes() then return end
 
+		-- Check if incoming spell is filtered
+		if IsDamageFiltered(args.spellId) then return end
+
 		local message = _G["COMBAT_TEXT_"..args.missType]
 
 		-- Add Icons


### PR DESCRIPTION
Filtering a spell because it's too spammy is kind of ruined by the fact that if that spell is resisted/immuned/absorbed etc. it still shows. 

The idea of this PR is to check if the spell is filtered before showing any miss information.

fixes #186, fixes #177