### PR TITLE
Add setting to show/not show absorbs in outgoing frame

### DIFF
--- a/config/profile.lua
+++ b/config/profile.lua
@@ -390,6 +390,7 @@ addon.defaults = {
         ["enableHots"] = true,
         ["enableImmunes"] = true,
         ["enableMisses"] = true,
+        ["enableAbsorbs"] = true,
         ["enablePartialMisses"] = false,
         ["showHighestPartialMiss"] = false,
         ["enableKillCommand"] = false,

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -217,6 +217,7 @@ local function ShowDots() return x.db.profile.frames["outgoing"].enableDotDmg en
 local function ShowHots() return x.db.profile.frames["outgoing"].enableHots end
 local function ShowImmunes() return x.db.profile.frames["outgoing"].enableImmunes end -- outgoing immunes
 local function ShowMisses() return x.db.profile.frames["outgoing"].enableMisses end -- outgoing misses
+local function ShowAbsorbs() return x.db.profile.frames["outgoing"].enableAbsorbs end -- outgoing absorbs
 local function ShowPartialMisses() return x.db.profile.frames["outgoing"].enablePartialMisses end
 local function ShowPetCrits() return x.db.profile.frames["critical"].petCrits end
 local function ShowLootItems() return x.db.profile.frames["loot"].showItems end
@@ -535,7 +536,7 @@ local COMBATLOG_FILTER_MY_VEHICLE = bit.bor( COMBATLOG_OBJECT_AFFILIATION_MINE,
   to go.
 --]=====================================================]
 function x.OnCombatTextEvent(self, event, ...)
-	
+
 	--[====[
 	if event == "COMBAT_LOG_EVENT_UNFILTERED" then
     local timestamp, eventType, hideCaster, sourceGUID, sourceName, sourceFlags, srcFlags2, destGUID, destName, destFlags, destFlags2 = CombatLogGetCurrentEventInfo()
@@ -1746,6 +1747,7 @@ local CombatEventHandlers = {
 		end
 
 		-- Check for filtered immunes
+		if args.missType == "ABSORB" and not ShowAbsorbs() then return end
 		if args.missType == "IMMUNE" and not ShowImmunes() then return end
 		if args.missType ~= "IMMUNE" and not ShowMisses() then return end
 

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -780,7 +780,7 @@ addon.options.args["spells"] = {
         },
       },
     },
-	
+
     raceList = {
       name = "Racial Spells",
       type = 'group',
@@ -3327,7 +3327,7 @@ addon.options.args["Frames"] = {
               get = get2,
               set = set2,
             },
-            
+
             healingSettings = {
               type = 'description',
               order = 30,
@@ -3447,8 +3447,16 @@ addon.options.args["Frames"] = {
               get = get2,
               set = set2,
             },
-            enablePartialMisses = {
+            enableAbsorbs = {
               order = 53,
+              type = 'toggle',
+              name = "Show Absorbs",
+              desc = "Display 'Absorb' when your target absorbs all damage.",
+              get = get2,
+              set = set2,
+            },
+            enablePartialMisses = {
+              order = 54,
               type = 'toggle',
               name = "Show Miss Types (Partials)",
               desc = "Show when your target takes only a percentage of your damage because it was partially absorbed, resisted, or blocked.\n\n|cffFF0000PLEASE NOTE:|r Only works if the spell is not merged. Turn off the Spell Merger to see all spells.",
@@ -3456,7 +3464,7 @@ addon.options.args["Frames"] = {
               set = set2,
             },
             showHighestPartialMiss = {
-              order = 54,
+              order = 55,
               type = 'toggle',
               name = "Show the Highest Partial Miss",
               desc = "Only show the highest partial miss, instead of all the misses. (Rare, but less spammy)\n\n|cffFF0000PLEASE NOTE:|r Only works if the spell is not merged. Turn off the Spell Merger to see all spells.",
@@ -6302,7 +6310,7 @@ addon.options.args["Frames"] = {
               set = set2,
               width = "normal",
             },
-            
+
 
           },
         },


### PR DESCRIPTION
Follows pattern of other miss-filtering that applies for full absorbs.
This partially fixes dandruff/xCT#177