### PR TITLE
Add form templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: [bug]
+# assignees:
+#   - dandruff
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: input
+    id: wow-version
+    attributes:
+      label: WoW version
+      description: |
+        What is the version of your World of Warcraft retail?
+        Found either below the "Play" button in the Battle.NET launcher, or bottom left corner of login screen.
+      placeholder: ex. 9.1.0.39291
+    validations:
+      required: true
+  - type: input
+    id: xct-version
+    attributes:
+      label: xCT+ version
+      description: |
+        What is the version of your xCT+?
+        Found at the top of the xCT+ configuratin window (`/xct`).
+        If you can't open the config, look in the `interface/AddOns/xCT+/xCT+.toc`.
+      placeholder: ex. 4.5.5
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: errors
+    attributes:
+      label: Related Errors
+      description: Please paste any errors you're seeing from xCT+ related to this issue
+      render: lua

--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -50,4 +50,6 @@ body:
     attributes:
       label: Related Errors
       description: Please paste any errors you're seeing from xCT+ related to this issue
+      placeholder: |
+        Message: Interface\AddOns\xCT+\...
       render: lua

--- a/.github/ISSUE_TEMPLATE/Feature Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature Request.yml
@@ -1,0 +1,26 @@
+name: Feature Request
+description: Request a feature
+title: "[feature]: "
+labels: [feature]
+# assignees:
+#   - dandruff
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to request a feature!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the feature you're requesting.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Feature request
+      description: What feature would you like to request
+      placeholder: It would be great if....
+    validations:
+      required: true


### PR DESCRIPTION
There's been multiple issues where people are reporting issues without specifying what their version of the addon is. This is most likely because the latest versions are marked as beta so people are not installing them, but I thought that it'd be helpful for you if people were prompted to fill out what version of the addon and wow they have. 

Github recently launched nifty feature where you can use forms for your issues, so I whipped two up. One for bug report and one for feature request. Could have more, could have specific templates for adding to spam merging etc. I suppose.

This is how it looks 
![image](https://user-images.githubusercontent.com/13413409/124473943-37774000-dda0-11eb-9aaa-83efcee67089.png)

