### PR TITLE
Fix shadowlands trinkets using incorrect ID

### DIFF
--- a/config/merge_shadowlands.lua
+++ b/config/merge_shadowlands.lua
@@ -48,20 +48,15 @@ end
 
 header "|cffd2d3d8ShadowLands|r™ |cff798BDDTrinkets|r"
 do
-	item '180117' '0.5' "Empyreal Ordnance"
-	alias '344540' '180117' -- Empyreal Ordnance dot
+	item '344540' '0.5' "Empyreal Ordnance"
 
-	item '178769' '1.0' "Infinitely Divisible Ooze"
-	alias '345495' '178769' -- Infinitely Divisible Ooze damage
+	item '345495' '1.0' "Infinitely Divisible Ooze"
 
-	item '178772' '0.5' "Satchel of Misbegotten Minions"
-	alias '345638' '178772' -- Satchel of Misbegotten Minions damage
+	item '345638' '0.5' "Satchel of Misbegotten Minions"
 
-	item '184021' '2.0' "Glyph of Assimilation"
-	alias '345319' '184021' -- Glyph of Assimilation dot
+	item '345319' '2.0' "Glyph of Assimilation"
 
-	item '182453' '0.5' "Twilight Bloom"
-	alias '339545' '182453' -- Twilight Bloom: Twilight Restoration
+	item '339545' '0.5' "Twilight Bloom"
 end
 
 header "|cffd2d3d8ShadowLands|r™ |cff798BDDLegendaries|r"


### PR DESCRIPTION
I noticed that the trinkets that was added in dandruff/xCT#172 misunderstood that "item" still expects the spell ID, and entered the trinkets item id instead, causing the merger to use completely incorrect spellIDs