### PR TITLE
Add merges and a few DF trinkets + Enchants + Legendary

### DIFF
--- a/config/include.xml
+++ b/config/include.xml
@@ -8,5 +8,6 @@
 	<Script file="merge_other.lua"/>
 	<Script file="merge_allied_race.lua"/>
 	<Script file="merge_shadowlands.lua"/>
+	<Script file="merge_dragonflight.lua"/>
 	<Script file="profile.lua"/>
 </Ui>

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -108,6 +108,7 @@ do
 	spell '179057' '0.5' --  Chaos Nova
 	spell '203796' '2.5' --  Talent: Demon Blades
 	spell '211052' '1.5' --  Talent: Fel Barrage
+	spell '390197' '0.5' --  Talent: Ragefire
 	spell '202388' '0.5' --  Artifact: Inner Demons
 	spell '201628' '1.5' --  Artifact: Fury of the Illidari
 	spell '217070' '0.5' --  Artifact: Rage of the Illidari
@@ -611,7 +612,7 @@ do
 	spell '278350' '1.0' --  Talent Vile Taint
 	alias '231489' '233490' --  Unstable Affliction (Artifact: Compounding Horror)
 
-	spec  '266' -- Demonlogy
+	spec  '266' -- Demonology
 	spell '603'    '0.5' --  Doom
 	spell '89753'  '2.5' --  Felguard: Felstorm
 	spell '104318' '1.5' --  Wild Imp: Fel Firebolt

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -45,8 +45,6 @@ do
 	spell '203166' '2.5' --  PVP Talent: Blight (ID: 203172)
 	spell '203174' '0.5' --  PVP Talent: Death Chain (ID: 203173)
 	alias '49998' '45470' -- Death Strike (DRW)
-	-- TODO Consumption
-	-- TODO Blooddrinker Heal
 
 	spec  '251' -- Frost
 	spell '196771' '2.5' --  Remorseless Winter

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -385,17 +385,19 @@ do
 	spell '105421' '0.5'  --  Talent: Blinding Light
 	spell '183811' '2.5'  --  Talent: Judgment of Light
 	spell '403460' '1.0'  --  Talent: Lightforged Blessing
-	spell '377129' '1.0'  --  Talent: Golden Path
+	spell '377129' '2.5'  --  Talent: Golden Path
+	alias '384906' '377129'  --  Talent: Seal of Mercy (merged into Golden Path)
 	alias '407467' '403460'  --  Talent: Lightforged Blessing
 
 	spec  '65' -- Holy
 	spell '225311' '0.5'  --  Light of Dawn
-	spell '53652'  '1.5'  --  Becon of Light
+	spell '53652'  '1.5'  --  Beacon of Light
 	spell '119952' '2.5'  --  Talent: Light's Hammer (Heal)
 	spell '114919' '2.5'  --  Talent: Light's Hammer (Damage)
 	spell '114852' '0.5'  --  Talent: Holy Prism (Heal)
 	spell '114871' '0.5'  --  Talent: Holy Prism (Damage)
 	spell '210291' '2.5'  --  Talent: Aura of Mercy
+	spell '392903' '0.5'  --  Talent: Resplendent Light
 	spell '200654' '2.5'  --  Artifact: Tyr's Deliverance
 
 	spec  '66' -- Protection

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -233,6 +233,9 @@ do
 	spell '212680' '0.5' --  Talent: Explosive Shot
 	spell '214581' '1.5' --  Talent: Sidewinders
 	spell '198670' '0.5' --  Talent: Piercing Shot
+	spell '260247' '0.5' --  Talent: Volley
+	spell '392058' '0.5' --  Talent: Wailing Arrow
+	spell '191043' '0.5' --  Talent: Wind Arrow
 	spell '191070' '0.5' --  Artifact: Call of the Hunter
 	spell '257045' '2.0' --  Rapid Fire
 	spell '257620' '2.0' --  Multi shot
@@ -500,6 +503,7 @@ do
 	spell '113780' '0.5' --  Deadly Poison (Instant)
 	spell '51723'  '0.5' --  Fan of Knives
 	spell '192660' '2.5' --  Poison Bomb
+	spell '121411' '2.5' --  Talent: Crimson Tempest (DoT)
 	alias '192380' '113780' --  Artifact: Poison Knives
 	alias '27576'  '5374'    --  Mutilate (OH)
 

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -314,6 +314,7 @@ do
 	spell '228598' '1.0' --  Talent: Spliting Ice
 	spell '113092' '1.0' --  Talent: Frost Bomb
 	spell '157978' '0.5' --  Talent: Unstable Magic
+	spell '418735' '0.5' --  Talent: Splintering Ray
 end
 
 

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -700,3 +700,10 @@ do
 	spell '222944' '3.0' --  Talent: Inspiring Presence
 	spell '203526' '3.5' --  Artifact: Neltharion's Fury
 end
+
+
+class 'EVOKER'
+do
+	spec  '0' -- All Specs
+	spell '357209'  '0.5' --  Fire Breath
+end

--- a/config/merge_class.lua
+++ b/config/merge_class.lua
@@ -23,23 +23,30 @@ local spell, class, spec, alias = unpack(addon.merge_helpers)
 
 class 'DEATHKNIGHT'
 do
+
 	spec  '0' -- All Specs
 	spell '52212' '2.5' --  Death and Decay
 	spell '268194' '1.0' -- chocking brine
-
+	spell '45470'  '0.5' -- Death Strike
+	
 	spec  '250' -- Blood
 	spell '55078'  '3.5' --  Blood Plague
 	spell '50842'  '0.5' --  Blood Boil
 	spell '195292' '0.5' --  Death's Caress (DRW)
-	spell '49998'  '0.5' --  Death Strike (DRW)
 	spell '206930' '0.5' --  Heart Strike
 	spell '212744' '0.5' --  Talent: Soulgorge
 	spell '196528' '1.5' --  Talent: Bonestorm (DMG)
 	spell '196545' '1.5' --  Talent: Bonestorm (Heal)
+	spell '377642' '0.5' --  Talent: Shattering Bone
+	spell '383313' '1.0' --  Talent: Abomination Limb
+	spell '274156' '0.5' --  Talent: Consumption (DMG)
 	spell '205223' '0.5' --  Artifact: Consumption (DMG)
 	spell '205224' '0.5' --  Artifact: Consumption (Heal)
 	spell '203166' '2.5' --  PVP Talent: Blight (ID: 203172)
 	spell '203174' '0.5' --  PVP Talent: Death Chain (ID: 203173)
+	alias '49998' '45470' -- Death Strike (DRW)
+	-- TODO Consumption
+	-- TODO Blooddrinker Heal
 
 	spec  '251' -- Frost
 	spell '196771' '2.5' --  Remorseless Winter
@@ -172,6 +179,9 @@ do
 	spell '77758'  '2.5' --  Thrash (Bear)
 	spell '213709' '2.5' --  Talent: Brambles
 	spell '204069' '2.5' --  Talent: Lunbar Beam
+	spell '400360' '1.0' --  Talent: Moonless Night
+	spell '400254' '0.5' --  Talent: Raze
+	spell '371982' '1.0' --  Talent: After the Wildfire
 	spell '219432' '2.5' --  Artifact: Rage of the Sleeper
 	alias '192090' '77758'  --  [DD/DoT Merger] Thrash
 	alias '203958' '213709' --  [Barkskin Merger] Brambles
@@ -371,6 +381,9 @@ do
 	spell '81297'  '2.5'  --  Consecration
 	spell '105421' '0.5'  --  Talent: Blinding Light
 	spell '183811' '2.5'  --  Talent: Judgment of Light
+	spell '403460' '1.0'  --  Talent: Lightforged Blessing
+	spell '377129' '1.0'  --  Talent: Golden Path
+	alias '407467' '403460'  --  Talent: Lightforged Blessing
 
 	spec  '65' -- Holy
 	spell '225311' '0.5'  --  Light of Dawn
@@ -388,27 +401,35 @@ do
 	spell '53600'  '0.5'  --  Shield of the Righteous
 	spell '204301' '2.5'  --  Blessed Hammer
 	spell '204241' '2.0'  --  Talent: Consecrated Ground
-	spell '209478' '1.5'  --  Artifact: Tyr's Enforcer
-	spell '209202' '0.5'  --  Artifact: Eye of Tyr
+	spell '378286' '1.5'  --  Talent: Tyr's Enforcer
+	spell '387174' '0.5'  --  Talent: Eye of Tyr
+	spell '425261' '0.5'  --  Amirdrassil Tier Set: Cleansing Flame
 
 	spec  '70' -- Retribution
 	spell '20271' ' 0.5'  --  Judgment
 	spell '217020' '0.5'  --  Zeal
 	spell '203539' '5.5'  --  Greater Blessings of Wisdom
+	spell '53385'  '0.5'  --  Divine Storm
 	spell '184689' '0.5'  --  Shield of Vengeance
+	spell '404358' '0.5'  --  Blade of Justice
 	spell '20271'  '1.5'  --  Talent: Greater Judgment
 	spell '198137' '2.5'  --  Talent: Divine Hammer
 	spell '210220' '0.5'  --  Talent: Holy Wrath
 	spell '202202' '0.5'  --  Talent: Eye for an Eye
 	spell '199435' '1.0'  --  Talent (PvP): Luminescence
 	spell '157122' '1.5'  --  Talent: Holy Shield
+	spell '405345' '2.0'  --  Talent: Wake of Ashes
+	spell '408385' '0.5'  --  Talent: Crusading Strikes
+	spell '343721' '0.5'  --  Talent: Final Reckoning
 	spell '224239' '1.5'  --  Artifact: Echo of the Highlord (Divine Storm)
 	spell '224266' '1.25' --  Artifact: Echo of the Highlord (Templar's Verdict)
-	spell '205273' '2.0'  --  Artifact: Wake of Ashes
 	spell '224239' '1.5'  --  Artifact: Divine Tempest (Divine Storm)
 	spell '215257' '1.75' --  Artifact: Healing Storm
 	alias '228288' '20271' --  [Bounce Merger] Judgment
 	alias '216527' '20271' --  [Pvp Talent - Bounce Merger]: Lawbringer
+	alias '184575' '404358'  --  Talent: Blade of Vengeance into Blade of Justice
+	alias '255937' '405345'  --  Talent: Wake of Ashes
+	alias '405350' '405345'  --  Talent: Wake of Ashes
 end
 
 

--- a/config/merge_dragonflight.lua
+++ b/config/merge_dragonflight.lua
@@ -1,0 +1,45 @@
+--[[   ____    ______
+      /\  _`\ /\__  _\   __
+ __  _\ \ \/\_\/_/\ \/ /_\ \___
+/\ \/'\\ \ \/_/_ \ \ \/\___  __\
+\/>  </ \ \ \L\ \ \ \ \/__/\_\_/
+ /\_/\_\ \ \____/  \ \_\  \/_/
+ \//\/_/  \/___/    \/_/
+
+ [=====================================]
+ [  Author: Dandraffbal-Stormreaver US ]
+ [  xCT+ Version 4.x.x                 ]
+ [  ©2020. All Rights Reserved.        ]
+ [====================================]]
+
+local ADDON_NAME, addon = ...
+
+-- New way of doing merge items
+-- 'alias' takes the original spell id and a replacement spell id
+-- item takes a item id, the merge interval in seconds, and a helpful description of the item
+-- header switches the header for the next set of items
+local spell, _, _, alias, item, header = unpack(addon.merge_helpers)
+
+
+header "|cffd2d3d8Dragonflight|r™ |cff798BDDTrinkets|r"
+do
+	item '426564' '1.0' "Augury of the Primal Flame"
+	
+	item '425701' '1.0' "Tainted Rageheart"
+	alias '425461' '425701' -- Shadowflame Lash
+	
+	item '425509' '1.0' "Branch of the Tormented Ancient"
+end
+
+header "|cffd2d3d8Dragonflight|r™ |cff798BDDLegendaries|r"
+do
+	item '417134' '0.5' "Rage of Fyr'alath"	
+	alias '424094' '417134' -- Rage of Fyr'alath
+	alias '413584' '417134' -- Explosive Rage
+end
+
+header "|cffd2d3d8Dragonflight|r™ |cff798BDDEnchants|r"
+do
+	item '426288' '0.5' "Smolderon's Delusions of Grandeur"	
+end
+

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -89,6 +89,7 @@ x.POWER_LOOKUP = {
 	[16] = "ARCANE_CHARGES",
 	[17] = "FURY",
 	[18] = "PAIN",
+	[25] = "VIGOR",
 }
 
 
@@ -1832,6 +1833,10 @@ local CombatEventHandlers = {
 
 	["SpellEnergize"] = function (args)
 		local amount, energy_type = args.amount, x.POWER_LOOKUP[args.powerType]
+		if not energy_type then 
+		    print('xct: unknown SpellEnergize power type: ' .. args.powerType) 
+		    return 
+		end
 		if not ShowEnergyGains() then return end
 		if FilterPlayerPower(mabs(tonumber(amount))) then return end
 		if IsResourceDisabled( energy_type, amount ) then return end

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -868,6 +868,7 @@ x.events = {
       end
     end,
   ["RUNE_POWER_UPDATE"] = function(slot)
+	  if slot < 0 then return end
       if GetRuneCooldown(slot) ~= 0 then return end
       local message = sformat(format_gain_rune, x.runeIcons[4], COMBAT_TEXT_RUNE_DEATH, x.runeIcons[4])
       x:AddSpamMessage("power", RUNES, message, x.runecolors[4], 1)

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -868,7 +868,7 @@ x.events = {
       end
     end,
   ["RUNE_POWER_UPDATE"] = function(slot)
-	  if slot < 0 then return end
+      if slot < 0 then return end
       if GetRuneCooldown(slot) ~= 0 then return end
       local message = sformat(format_gain_rune, x.runeIcons[4], COMBAT_TEXT_RUNE_DEATH, x.runeIcons[4])
       x:AddSpamMessage("power", RUNES, message, x.runecolors[4], 1)


### PR DESCRIPTION
The merges are checked by me using chars of myself, so they should be good.
I did not cleanup all the old IDs, maybe that should be done sometimes in the future?

Re: the DK Runes fix: it seems like the slot # is getting negative. Why? IDK, I just added the catch clause. It would be worth investigating why its getting negative though.

For the vigor change: Just adding this to the global array fixed the error, IDK what else would be necessary to properly add xct notifications for gaining a vigor charge.