### PR TITLE
Fix incoming damage text

### DIFF
--- a/config/merge_mop.lua
+++ b/config/merge_mop.lua
@@ -22,10 +22,10 @@ local _, _, _, alias, item, header = unpack(addon.merge_helpers)
 
 header " 5.x |cffF1A864Mists of Pandaria|r™ |cff798BDDLegendary Cloaks|r"
 do
-	item '147891' '3.5' "Legedary Cloak for Melee"
-	item '148008' '3.5' "Legedary Cloak for Casters"
-	item '148009' '5.0' "Legedary Cloak for Healers"
-	item '149276' '3.5' "Legedary Cloak for Hunters"
+	item '147891' '3.5' "Legendary Cloak for Melee"
+	item '148008' '3.5' "Legendary Cloak for Casters"
+	item '148009' '5.0' "Legendary Cloak for Healers"
+	item '149276' '3.5' "Legendary Cloak for Hunters"
 end
 
 header " 5.x |cffF1A864Mists of Pandaria|r™ |cff798BDDTrinkets|r"

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1098,7 +1098,7 @@ local function hexNameColor(t)
     return sformat("ff%2X%2X%2X", mfloor(t[1]*255+.5), mfloor(t[2]*255+.5), mfloor(t[3]*255+.5))
 end
 
--- Checks the options you provide and outputs the correctly formated name
+-- Checks the options you provide and outputs the correctly formatted name
 local function formatNameHelper(name, enableColor, color, enableCustomColor, customColor)
     if enableColor then
         if enableCustomColor then
@@ -1155,7 +1155,7 @@ formatNameTypes = {
 
     function (args, settings, isSource) -- [2] = Spell Name
         local color
-            if settings.enableNameColor and not settings.enableCustomNameColor then
+        if settings.enableNameColor and not settings.enableCustomNameColor then
 
             -- NOTE: I don't think we want the spell school of the spell
             --       being cast. We want the spell school of the damage
@@ -1190,7 +1190,7 @@ formatNameTypes = {
     end
 }
 
--- Check to see if the name needs for be formated, if so, handle all the logistics
+-- Check to see if the name needs for be formatted, if so, handle all the logistics
 function x.formatName(args, settings, isSource)
     -- Event Type helper
     local index = isSource and (args.fake_sourceController or args:GetSourceController())

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -585,6 +585,9 @@ function x:GetSpellTextureFormatted( spellID, message, iconSize, showInvisibleIc
     icon = PET_ATTACK_TEXTURE
   elseif type(spellID) == 'string' then
     icon = spellID
+  elseif spellID == 6603 then
+    -- Auto attack
+    icon = x.BLANK_ICON
   else
     icon = C_Spell.GetSpellTexture( addon.merge2h[spellID] or spellID ) or x.BLANK_ICON
   end
@@ -1579,6 +1582,7 @@ local CombatEventHandlers = {
         end
 
         if MergeSpells() then
+          print('DamageIncoming ' .. args.spellId .. ' ' .. args.amount)
             x:AddSpamMessage(
                 'damage',
                 args.spellId,

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -70,26 +70,26 @@ end
  Power Type Definitions
 --]=====================================================]
 x.POWER_LOOKUP = {
-	[0] = "MANA",
-	[1] = "RAGE",
-	[2] = "FOCUS",
-	[3] = "ENERGY",
-	[4] = "COMBO_POINTS",
-	[5] = "RUNES",
-	[6] = "RUNIC_POWER",
-	[7] = "SOUL_SHARDS",
-	[8] = "LUNAR_POWER",
-	[9] = "HOLY_POWER",
-	[10] = "ALTERNATE_POWER_INDEX",
-	[11] = "MAELSTROM",
-	[12] = "CHI",
-	[13] = "INSANITY",
-	[14] = "BURNING_EMBERS",
-	[15] = "DEMONIC_FURY",
-	[16] = "ARCANE_CHARGES",
-	[17] = "FURY",
-	[18] = "PAIN",
-	[25] = "VIGOR",
+    [0] = "MANA",
+    [1] = "RAGE",
+    [2] = "FOCUS",
+    [3] = "ENERGY",
+    [4] = "COMBO_POINTS",
+    [5] = "RUNES",
+    [6] = "RUNIC_POWER",
+    [7] = "SOUL_SHARDS",
+    [8] = "LUNAR_POWER",
+    [9] = "HOLY_POWER",
+    [10] = "ALTERNATE_POWER_INDEX",
+    [11] = "MAELSTROM",
+    [12] = "CHI",
+    [13] = "INSANITY",
+    [14] = "BURNING_EMBERS",
+    [15] = "DEMONIC_FURY",
+    [16] = "ARCANE_CHARGES",
+    [17] = "FURY",
+    [18] = "PAIN",
+    [25] = "VIGOR",
 }
 
 
@@ -277,47 +277,47 @@ local function MergeDispells() return x.db.profile.spells.mergeDispells end
 
 local function FilterPlayerPower(value) return x.db.profile.spellFilter.filterPowerValue > value end
 local function FilterOutgoingDamage(value, critical)
-	if critical and x.db.profile.spellFilter.filterOutgoingDamageCritEnabled then
-		return x.db.profile.spellFilter.filterOutgoingDamageCritValue > value
-	else
-		return x.db.profile.spellFilter.filterOutgoingDamageValue > value
-	end
+    if critical and x.db.profile.spellFilter.filterOutgoingDamageCritEnabled then
+        return x.db.profile.spellFilter.filterOutgoingDamageCritValue > value
+    else
+        return x.db.profile.spellFilter.filterOutgoingDamageValue > value
+    end
 end
 local function FilterOutgoingHealing(value, critical)
-	if critical and x.db.profile.spellFilter.filterOutgoingHealingCritEnabled then
-		return x.db.profile.spellFilter.filterOutgoingHealingCritValue > value
-	else
-		return x.db.profile.spellFilter.filterOutgoingHealingValue > value
-	end
+    if critical and x.db.profile.spellFilter.filterOutgoingHealingCritEnabled then
+        return x.db.profile.spellFilter.filterOutgoingHealingCritValue > value
+    else
+        return x.db.profile.spellFilter.filterOutgoingHealingValue > value
+    end
 end
 local function FilterIncomingDamage(value, critical)
-	if critical and x.db.profile.spellFilter.filterIncomingDamageCritEnabled then
-		return x.db.profile.spellFilter.filterIncomingDamageCritValue > value
-	else
-		return x.db.profile.spellFilter.filterIncomingDamageValue > value
-	end
+    if critical and x.db.profile.spellFilter.filterIncomingDamageCritEnabled then
+        return x.db.profile.spellFilter.filterIncomingDamageCritValue > value
+    else
+        return x.db.profile.spellFilter.filterIncomingDamageValue > value
+    end
 end
 local function FilterIncomingHealing(value, critical)
-	if critical and x.db.profile.spellFilter.filterIncomingHealingCritEnabled then
-		return x.db.profile.spellFilter.filterIncomingHealingCritValue > value
-	else
-		return x.db.profile.spellFilter.filterIncomingHealingValue > value
-	end
+    if critical and x.db.profile.spellFilter.filterIncomingHealingCritEnabled then
+        return x.db.profile.spellFilter.filterIncomingHealingCritValue > value
+    else
+        return x.db.profile.spellFilter.filterIncomingHealingValue > value
+    end
 end
 local function TrackSpells() return x.db.profile.spellFilter.trackSpells end
 
 local function IsResourceDisabled( resource, amount )
-	if resource == "ECLIPSE" then
-		if amount > 0 then
-			return x.db.profile.frames["power"].disableResource_ECLIPSE_positive
-		elseif amount < 0 then
-			return x.db.profile.frames["power"].disableResource_ECLIPSE_negative
-		end
-	end
-	if x.db.profile.frames["power"]["disableResource_"..resource] ~= nil then
-		return x.db.profile.frames["power"]["disableResource_"..resource]
-	end
-	return true
+    if resource == "ECLIPSE" then
+        if amount > 0 then
+            return x.db.profile.frames["power"].disableResource_ECLIPSE_positive
+        elseif amount < 0 then
+            return x.db.profile.frames["power"].disableResource_ECLIPSE_negative
+        end
+    end
+    if x.db.profile.frames["power"]["disableResource_"..resource] ~= nil then
+        return x.db.profile.frames["power"]["disableResource_"..resource]
+    end
+    return true
 end
 
 local function IsBearForm() return GetShapeshiftForm() == 1 and x.player.class == "DRUID" end
@@ -374,7 +374,7 @@ local function IsHealingFiltered(name)
 end
 
 local function MergeSpells()
-	return x.db.profile.spells.enableMerger
+    return x.db.profile.spells.enableMerger
 end
 
 local function UseStandardSpellColors() return not x.db.profile.frames["outgoing"].standardSpellColor end
@@ -534,21 +534,21 @@ local COMBATLOG_FILTER_MY_VEHICLE = bit.bor( COMBATLOG_OBJECT_AFFILIATION_MINE,
 --]=====================================================]
 function x.OnCombatTextEvent(self, event, ...)
 
-	--[====[
-	if event == "COMBAT_LOG_EVENT_UNFILTERED" then
+    --[====[
+    if event == "COMBAT_LOG_EVENT_UNFILTERED" then
     local timestamp, eventType, hideCaster, sourceGUID, sourceName, sourceFlags, srcFlags2, destGUID, destName, destFlags, destFlags2 = CombatLogGetCurrentEventInfo()
-	--local timestamp, eventType, hideCaster, sourceGUID, sourceName, sourceFlags, srcFlags2, destGUID, destName, destFlags, destFlags2 = select(1, ...)
+    --local timestamp, eventType, hideCaster, sourceGUID, sourceName, sourceFlags, srcFlags2, destGUID, destName, destFlags, destFlags2 = select(1, ...)
 
     if sourceGUID == x.player.guid or
-    	( sourceGUID == UnitGUID("pet") and ShowPetDamage() ) or
-    	sourceFlags == COMBATLOG_FILTER_MY_VEHICLE
+        ( sourceGUID == UnitGUID("pet") and ShowPetDamage() ) or
+        sourceFlags == COMBATLOG_FILTER_MY_VEHICLE
     then
       if x.outgoing_events[eventType] then
         x.outgoing_events[eventType](...)
       end
     end
   else
-	]====]
+    ]====]
 
   if event == "COMBAT_TEXT_UPDATE" then
     local subevent, arg2, arg3 = ...
@@ -787,7 +787,7 @@ end
 x.combat_events = {
 
   ["SPELL_ACTIVE"] = function(spellName)
-	  if not spellName then return end -- trying to fix table index is nil error
+      if not spellName then return end -- trying to fix table index is nil error
       if TrackSpells() then x.spellCache.procs[spellName] = true end
       if IsProcFiltered(spellName) then return end
 
@@ -816,22 +816,22 @@ x.combat_events = {
   -- REMOVING PERIODIC_ENERGIZE, AS IT'S NOW COVERED BY SPELLENERGIZE Event
 
   -- TODO: Create a merger for faction and honor xp
-	["HONOR_GAINED"] = function() -- UNTESTED
-		local amount = GetCurrentCombatTextEventInfo()
-		local num = mfloor(tonumber(amount) or 0)
-		if num > 0 and ShowHonor() then
-			x:AddMessage('general', sformat(format_honor, HONOR, x:Abbreviate(amount,"general")), 'honorGains')
-		end
-	end,
+    ["HONOR_GAINED"] = function() -- UNTESTED
+        local amount = GetCurrentCombatTextEventInfo()
+        local num = mfloor(tonumber(amount) or 0)
+        if num > 0 and ShowHonor() then
+            x:AddMessage('general', sformat(format_honor, HONOR, x:Abbreviate(amount,"general")), 'honorGains')
+        end
+    end,
 
-	["FACTION"] = function() -- TESTED
-		local faction, amount = GetCurrentCombatTextEventInfo()
-		local num = mfloor(tonumber(amount) or 0)
-		if num > 0 and ShowFaction() then
-			x:AddMessage('general', sformat(format_faction_add, faction, x:Abbreviate(amount,'general')), 'reputationGain')
-		elseif num < 0 and ShowFaction() then
-			x:AddMessage('general', sformat(format_faction_sub, faction, x:Abbreviate(amount,'general')), 'reputationLoss')
-		end
+    ["FACTION"] = function() -- TESTED
+        local faction, amount = GetCurrentCombatTextEventInfo()
+        local num = mfloor(tonumber(amount) or 0)
+        if num > 0 and ShowFaction() then
+            x:AddMessage('general', sformat(format_faction_add, faction, x:Abbreviate(amount,'general')), 'reputationGain')
+        elseif num < 0 and ShowFaction() then
+            x:AddMessage('general', sformat(format_faction_sub, faction, x:Abbreviate(amount,'general')), 'reputationLoss')
+        end
     end,
 }
 
@@ -977,7 +977,7 @@ x.events = {
           local itemQualityColor = ITEM_QUALITY_COLORS[itemQuality]
           -- "%s%s: %s [%s]%s %%s"
           local message = sformat(format_lewtz,
-              ShowLootItemTypes() and itemType or "Item",		-- Item Type
+              ShowLootItemTypes() and itemType or "Item",        -- Item Type
               ShowColorBlindMoney()                     -- Item Quality (Color Blind)
                 and sformat(format_lewtz_blind,
                               _G[sformat(format_quality,
@@ -1085,121 +1085,121 @@ x.events = {
 -- Changes a color table into a hex string
 
 local function hexNameColor(t)
-	if type(t) == "string" then
-		return "ff"..t
-	elseif not t then
-		return "ffFFFFFF"
-	elseif t.colorStr then -- Support Blizzard's raid colors
-		return t.colorStr
-	end
-	return sformat("ff%2X%2X%2X", mfloor(t[1]*255+.5), mfloor(t[2]*255+.5), mfloor(t[3]*255+.5))
+    if type(t) == "string" then
+        return "ff"..t
+    elseif not t then
+        return "ffFFFFFF"
+    elseif t.colorStr then -- Support Blizzard's raid colors
+        return t.colorStr
+    end
+    return sformat("ff%2X%2X%2X", mfloor(t[1]*255+.5), mfloor(t[2]*255+.5), mfloor(t[3]*255+.5))
 end
 
 -- Checks the options you provide and outputs the correctly formated name
 local function formatNameHelper(name, enableColor, color, enableCustomColor, customColor)
-	if enableColor then
-		if enableCustomColor then
-			return "|c"..hexNameColor(customColor)..name.."|r"
-		end
-		return "|c"..hexNameColor(color)..name.."|r"
-	end
-	return "|cffFFFFFF"..name.."|r"
+    if enableColor then
+        if enableCustomColor then
+            return "|c"..hexNameColor(customColor)..name.."|r"
+        end
+        return "|c"..hexNameColor(color)..name.."|r"
+    end
+    return "|cffFFFFFF"..name.."|r"
 end
 
 -- Format Handlers for name
 local CLASS_LOOKUP = {
-	[1]    = "DEATHKNIGHT",
-	[2]    = "DEMONHUNTER",
-	[4]    = "DRUID",
-	[8]    = "EVOKER",
-	[16]   = "HUNTER",
-	[32]   = "MAGE",
-	[64]   = "MONK",
-	[128]  = "PALADIN",
-	[256]  = "PRIEST",
-	[512]  = "ROGUE",
-	[1024] = "SHAMAN",
-	[2048] = "WARLOCK",
-	[4096] = "WARRIOR"
+    [1]    = "DEATHKNIGHT",
+    [2]    = "DEMONHUNTER",
+    [4]    = "DRUID",
+    [8]    = "EVOKER",
+    [16]   = "HUNTER",
+    [32]   = "MAGE",
+    [64]   = "MONK",
+    [128]  = "PALADIN",
+    [256]  = "PRIEST",
+    [512]  = "ROGUE",
+    [1024] = "SHAMAN",
+    [2048] = "WARLOCK",
+    [4096] = "WARRIOR"
 }
 
 local formatNameTypes
 formatNameTypes = {
-	function (args, settings, isSource) -- [1] = Source/Destination Name
-		local guid, name, color = isSource and args.sourceGUID or args.destGUID, isSource and args.sourceName or args.destName
+    function (args, settings, isSource) -- [1] = Source/Destination Name
+        local guid, name, color = isSource and args.sourceGUID or args.destGUID, isSource and args.sourceName or args.destName
 
-		if settings.removeRealmName then
-			name = smatch(name, format_remove_realm) or name
-		end
+        if settings.removeRealmName then
+            name = smatch(name, format_remove_realm) or name
+        end
 
-		if settings.enableNameColor and not settings.enableCustomNameColor then
-			if args.prefix == "ENVIRONMENTAL" then
-				color = x.spellColors[args.school or args.spellSchool or 1]
-			else
-				if smatch(guid, "^Player") then
-					local _, class = GetPlayerInfoByGUID(guid)
-					color = RAID_CLASS_COLORS[class or 0]
-				end
-			end
-		end
+        if settings.enableNameColor and not settings.enableCustomNameColor then
+            if args.prefix == "ENVIRONMENTAL" then
+                color = x.spellColors[args.school or args.spellSchool or 1]
+            else
+                if smatch(guid, "^Player") then
+                    local _, class = GetPlayerInfoByGUID(guid)
+                    color = RAID_CLASS_COLORS[class or 0]
+                end
+            end
+        end
 
-		return formatNameHelper(name,
-		               settings.enableNameColor,
-		                        color,
-		               settings.enableCustomNameColor,
-		               settings.customNameColor)
-	end,
+        return formatNameHelper(name,
+                       settings.enableNameColor,
+                                color,
+                       settings.enableCustomNameColor,
+                       settings.customNameColor)
+    end,
 
-	function (args, settings, isSource) -- [2] = Spell Name
-		local color
-			if settings.enableNameColor and not settings.enableCustomNameColor then
+    function (args, settings, isSource) -- [2] = Spell Name
+        local color
+            if settings.enableNameColor and not settings.enableCustomNameColor then
 
-			-- NOTE: I don't think we want the spell school of the spell
-			--       being cast. We want the spell school of the damage
-			--       being done. That said, if you want to change it so
-			--       that the spell name matches the type of spell it
-			--       is, and not the type of damage it does, change
-			--       "args.school" to "args.spellSchool".
-			color = x.GetSpellSchoolColor(args.school or args.spellSchool)
-		end
+            -- NOTE: I don't think we want the spell school of the spell
+            --       being cast. We want the spell school of the damage
+            --       being done. That said, if you want to change it so
+            --       that the spell name matches the type of spell it
+            --       is, and not the type of damage it does, change
+            --       "args.school" to "args.spellSchool".
+            color = x.GetSpellSchoolColor(args.school or args.spellSchool)
+        end
 
-		return formatNameHelper(args.spellName,
-		                    settings.enableSpellColor,
-		                             color,
-		                    settings.enableCustomSpellColor,
-		                    settings.customSpellColor)
-	end,
+        return formatNameHelper(args.spellName,
+                            settings.enableSpellColor,
+                                     color,
+                            settings.enableCustomSpellColor,
+                            settings.customSpellColor)
+    end,
 
-	function (args, settings, isSource) -- [3] = Source Name - Spell Name
-		if args.hideCaster then
-			return formatNameTypes[2](args, settings, isSource)
-		end
+    function (args, settings, isSource) -- [3] = Source Name - Spell Name
+        if args.hideCaster then
+            return formatNameTypes[2](args, settings, isSource)
+        end
 
-		return formatNameTypes[1](args, settings, isSource) .. " - " .. formatNameTypes[2](args, settings, isSource)
-	end,
+        return formatNameTypes[1](args, settings, isSource) .. " - " .. formatNameTypes[2](args, settings, isSource)
+    end,
 
-	function (args, settings, isSource) -- [4] = Spell Name - Source Name
-		if args.hideCaster then
-			return formatNameTypes[2](args, settings, isSource)
-		end
+    function (args, settings, isSource) -- [4] = Spell Name - Source Name
+        if args.hideCaster then
+            return formatNameTypes[2](args, settings, isSource)
+        end
 
-		return formatNameTypes[2](args, settings, isSource) .. " - " .. formatNameTypes[1](args, settings, isSource)
-	end
+        return formatNameTypes[2](args, settings, isSource) .. " - " .. formatNameTypes[1](args, settings, isSource)
+    end
 }
 
 -- Check to see if the name needs for be formated, if so, handle all the logistics
 function x.formatName(args, settings, isSource)
-	-- Event Type helper
-	local index = isSource and (args.fake_sourceController or args:GetSourceController())
-													or (args.fake_destinationController or args:GetDestinationController())
+    -- Event Type helper
+    local index = isSource and (args.fake_sourceController or args:GetSourceController())
+                                                    or (args.fake_destinationController or args:GetDestinationController())
 
-	local eventType = settings[index]
+    local eventType = settings[index]
 
-	-- If we have a valid event type that we can handle
-	if eventType and eventType.nameType > 0 then
-		return settings.namePrefix .. formatNameTypes[eventType.nameType](args, eventType, isSource) .. settings.namePostfix
-	end
-	return "" -- Names not supported
+    -- If we have a valid event type that we can handle
+    if eventType and eventType.nameType > 0 then
+        return settings.namePrefix .. formatNameTypes[eventType.nameType](args, eventType, isSource) .. settings.namePostfix
+    end
+    return "" -- Names not supported
 end
 
 -- =====================================================
@@ -1207,72 +1207,72 @@ end
 -- =====================================================
 
 local missTypeColorLookup = {
-	['MISS'] = 'missTypeMiss',
-	['DODGE'] = 'missTypeDodge',
-	['PARRY'] = 'missTypeParry',
-	['EVADE'] = 'missTypeEvade',
-	['IMMUNE'] = 'missTypeImmune',
-	['DEFLECT'] = 'missTypeDeflect',
-	['REFLECT'] = 'missTypeReflect'
+    ['MISS'] = 'missTypeMiss',
+    ['DODGE'] = 'missTypeDodge',
+    ['PARRY'] = 'missTypeParry',
+    ['EVADE'] = 'missTypeEvade',
+    ['IMMUNE'] = 'missTypeImmune',
+    ['DEFLECT'] = 'missTypeDeflect',
+    ['REFLECT'] = 'missTypeReflect'
 }
 
 local PARTIAL_MISS_FORMATTERS = {
-	['absorbed'] = " |c%s"..(TEXT_MODE_A_STRING_RESULT_ABSORB:gsub("%%d","%%s")).."|r", -- |c%s(%s Absorbed)|r
-	['blocked']  = " |c%s"..( TEXT_MODE_A_STRING_RESULT_BLOCK:gsub("%%d","%%s")).."|r", -- |c%s(%s Blocked)|r
-	['resisted'] = " |c%s"..(TEXT_MODE_A_STRING_RESULT_RESIST:gsub("%%d","%%s")).."|r", -- |c%s(%s Resisted)|r
+    ['absorbed'] = " |c%s"..(TEXT_MODE_A_STRING_RESULT_ABSORB:gsub("%%d","%%s")).."|r", -- |c%s(%s Absorbed)|r
+    ['blocked']  = " |c%s"..( TEXT_MODE_A_STRING_RESULT_BLOCK:gsub("%%d","%%s")).."|r", -- |c%s(%s Blocked)|r
+    ['resisted'] = " |c%s"..(TEXT_MODE_A_STRING_RESULT_RESIST:gsub("%%d","%%s")).."|r", -- |c%s(%s Resisted)|r
 }
 
 local PARTIAL_MISS_COLORS = {
-	['absorbed'] = 'missTypeAbsorbPartial',
-	['blocked']  = 'missTypeBlockPartial',
-	['resisted'] = 'missTypeResistPartial',
+    ['absorbed'] = 'missTypeAbsorbPartial',
+    ['blocked']  = 'missTypeBlockPartial',
+    ['resisted'] = 'missTypeResistPartial',
 }
 
 local FULL_MISS_COLORS = {
-	['absorbed'] = 'missTypeAbsorb',
-	['blocked']  = 'missTypeBlock',
-	['resisted'] = 'missTypeResist',
+    ['absorbed'] = 'missTypeAbsorb',
+    ['blocked']  = 'missTypeBlock',
+    ['resisted'] = 'missTypeResist',
 }
 
 
 local function GetPartialMiss(args, settings, outgoingFrame)
-	local blocked, absorbed, resisted = args.blocked or 0, args.absorbed or 0, args.resisted or 0
-	if blocked > 0 or absorbed > 0 or resisted > 0 then
+    local blocked, absorbed, resisted = args.blocked or 0, args.absorbed or 0, args.resisted or 0
+    if blocked > 0 or absorbed > 0 or resisted > 0 then
 
-		-- Show only the highest partial miss
-		if settings.showHighestPartialMiss then
-			local maxType, color
-			if blocked > absorbed then
-				if blocked > resisted then maxType = 'blocked' else maxType = 'resisted' end
-			else
-				if absorbed > resisted then maxType = 'absorbed' else maxType = 'resisted' end
-			end
+        -- Show only the highest partial miss
+        if settings.showHighestPartialMiss then
+            local maxType, color
+            if blocked > absorbed then
+                if blocked > resisted then maxType = 'blocked' else maxType = 'resisted' end
+            else
+                if absorbed > resisted then maxType = 'absorbed' else maxType = 'resisted' end
+            end
 
-			color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS[maxType] or FULL_MISS_COLORS[maxType]))
-			return true, sformat(PARTIAL_MISS_FORMATTERS[maxType], color, x:Abbreviate(args[maxType], outgoingFrame))
-		end
+            color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS[maxType] or FULL_MISS_COLORS[maxType]))
+            return true, sformat(PARTIAL_MISS_FORMATTERS[maxType], color, x:Abbreviate(args[maxType], outgoingFrame))
+        end
 
-		-- Show All the partial misses that exsist
-		local message, color = ""
-		if absorbed > 0 then
-			color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS.absorbed or FULL_MISS_COLORS.absorbed))
-			message = message .. sformat(PARTIAL_MISS_FORMATTERS.absorbed, color, x:Abbreviate(absorbed, outgoingFrame))
-		end
+        -- Show All the partial misses that exsist
+        local message, color = ""
+        if absorbed > 0 then
+            color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS.absorbed or FULL_MISS_COLORS.absorbed))
+            message = message .. sformat(PARTIAL_MISS_FORMATTERS.absorbed, color, x:Abbreviate(absorbed, outgoingFrame))
+        end
 
-		if blocked > 0 then
-			color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS.blocked or FULL_MISS_COLORS.blocked))
-			message = message .. sformat(PARTIAL_MISS_FORMATTERS.blocked, color, x:Abbreviate(blocked, outgoingFrame))
-		end
+        if blocked > 0 then
+            color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS.blocked or FULL_MISS_COLORS.blocked))
+            message = message .. sformat(PARTIAL_MISS_FORMATTERS.blocked, color, x:Abbreviate(blocked, outgoingFrame))
+        end
 
-		if resisted > 0 then
-			color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS.resisted or FULL_MISS_COLORS.resisted))
-			message = message .. sformat(PARTIAL_MISS_FORMATTERS.resisted, color, x:Abbreviate(resisted, outgoingFrame))
-		end
+        if resisted > 0 then
+            color = hexNameColor(x.LookupColorByName(args.amount > 0 and PARTIAL_MISS_COLORS.resisted or FULL_MISS_COLORS.resisted))
+            message = message .. sformat(PARTIAL_MISS_FORMATTERS.resisted, color, x:Abbreviate(resisted, outgoingFrame))
+        end
 
-		return true, message
-	else
-		return false, ""
-	end
+        return true, message
+    else
+        return false, ""
+    end
 end
 
 
@@ -1281,743 +1281,756 @@ end
 --               The New Combat Handlers
 -- =====================================================
 local CombatEventHandlers = {
-	["ShieldOutgoing"] = function (args)
-		local buffIndex = x.findBuffIndex(args.destName, args.spellName)
-		if not buffIndex then return end
-		local settings, value = x.db.profile.frames['outgoing'], select(16, C_UnitAuras.GetBuffDataByIndex(args.destName, buffIndex))
-		if not value or value <= 0 then return end
+    ["ShieldOutgoing"] = function (args)
+        local buffIndex = x.findBuffIndex(args.destName, args.spellName)
+        if not buffIndex then return end
+        local settings, value = x.db.profile.frames['outgoing'], select(16, C_UnitAuras.GetBuffDataByIndex(args.destName, buffIndex))
+        if not value or value <= 0 then return end
 
-		-- Keep track of spells that go by
-		if TrackSpells() then x.spellCache.spells[args.spellId] = true end
+        -- Keep track of spells that go by
+        if TrackSpells() then x.spellCache.spells[args.spellId] = true end
 
-		if not ShowAbsorbs() then return end
+        if not ShowAbsorbs() then return end
 
-		-- Filter Ougoing Healing Spell or Amount
-		if IsSpellFiltered(args.spellId) or FilterOutgoingHealing(args.amount) then return end
+        -- Filter Ougoing Healing Spell or Amount
+        if IsSpellFiltered(args.spellId) or FilterOutgoingHealing(args.amount) then return end
 
-		-- Create the message
-		local message = x:Abbreviate(value, 'outgoing')
+        -- Create the message
+        local message = x:Abbreviate(value, 'outgoing')
 
-		message = x:GetSpellTextureFormatted(args.spellId,
-			                                   message,
-			    x.db.profile.frames['outgoing'].iconsEnabled and x.db.profile.frames['outgoing'].iconsSize or -1,
+        message = x:GetSpellTextureFormatted(args.spellId,
+                                               message,
+                x.db.profile.frames['outgoing'].iconsEnabled and x.db.profile.frames['outgoing'].iconsSize or -1,
           x.db.profile.frames['outgoing'].spacerIconsEnabled,
-			    x.db.profile.frames['outgoing'].fontJustify)
+                x.db.profile.frames['outgoing'].fontJustify)
 
-		-- Add names
-		message = message .. x.formatName(args, settings.names, true)
+        -- Add names
+        message = message .. x.formatName(args, settings.names, true)
 
-		x:AddMessage('outgoing', message, 'shieldOut')
-	end,
+        x:AddMessage('outgoing', message, 'shieldOut')
+    end,
 
-	["HealingOutgoing"] = function (args)
-		local spellName, spellSchool = args.spellName, args.spellSchool
-		local spellID, isHoT, amount, overhealing, merged = args.spellId, args.prefix == "SPELL_PERIODIC", args.amount, args.overhealing
+    ["HealingOutgoing"] = function (args)
+        local spellName, spellSchool = args.spellName, args.spellSchool
+        local spellID, isHoT, amount, overhealing, merged = args.spellId, args.prefix == "SPELL_PERIODIC", args.amount, args.overhealing
 
-		-- Keep track of spells that go by
-		if TrackSpells() then x.spellCache.spells[spellID] = true end
+        -- Keep track of spells that go by
+        if TrackSpells() then x.spellCache.spells[spellID] = true end
 
-		if not ShowHealing() then return end
+        if not ShowHealing() then return end
 
-		-- Check to see if this is a HoT
-		if isHoT and not ShowHots() then return end
+        -- Check to see if this is a HoT
+        if isHoT and not ShowHots() then return end
 
-		-- Filter Ougoing Healing Spell or Amount
-		if IsSpellFiltered(spellID) or FilterOutgoingHealing(amount) then return end
+        -- Filter Ougoing Healing Spell or Amount
+        if IsSpellFiltered(spellID) or FilterOutgoingHealing(amount) then return end
 
-		-- Filter Overhealing
-		if ShowOverHealing() then
-			if IsOverhealingSubtracted() then
-				amount = amount - overhealing
-			end
-		else
-			amount = amount - overhealing
-			overhealing = 0
-			if amount < 1 then return end
-		end
+        -- Filter Overhealing
+        if ShowOverHealing() then
+            if IsOverhealingSubtracted() then
+                amount = amount - overhealing
+            end
+        else
+            amount = amount - overhealing
+            overhealing = 0
+            if amount < 1 then return end
+        end
 
-		-- Figure out which frame and color to output
-		local outputFrame, outputColor, critical = "outgoing", "healingOut", args.critical
-		if critical then
-			outputFrame = "critical"
-			outputColor = "healingOutCritical"
-		end
+        -- Figure out which frame and color to output
+        local outputFrame, outputColor, critical = "outgoing", "healingOut", args.critical
+        if critical then
+            outputFrame = "critical"
+            outputColor = "healingOutCritical"
+        end
 
-		-- Get the settings for the correct output frame
-		local settings = x.db.profile.frames[outputFrame]
+        -- Get the settings for the correct output frame
+        local settings = x.db.profile.frames[outputFrame]
 
-		-- HoTs only have one color
-		if isHoT then outputColor = "healingOutPeriodic"end
+        -- HoTs only have one color
+        if isHoT then outputColor = "healingOutPeriodic"end
 
-		-- Condensed Critical Merge
-		if MergeSpells() then
-			merged = true
-			if critical then
-				if MergeCriticalsByThemselves() then
-					x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-					return
-				elseif MergeCriticalsWithOutgoing() then
-					x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-				elseif MergeHideMergedCriticals() then
-					x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-					return
-				end
-			else
-				x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-				return
-			end
-		end
+        -- Condensed Critical Merge
+        if MergeSpells() then
+            merged = true
+            if critical then
+                if MergeCriticalsByThemselves() then
+                    x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                    return
+                elseif MergeCriticalsWithOutgoing() then
+                    x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                elseif MergeHideMergedCriticals() then
+                    x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                    return
+                end
+            else
+                x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                return
+            end
+        end
 
-		if args.event == "SPELL_PERIODIC_HEAL" then
-			xCTFormat:SPELL_PERIODIC_HEAL(outputFrame, spellID, amount, overhealing, critical, merged, args, settings)
-		elseif args.event == "SPELL_HEAL" then
-			xCTFormat:SPELL_HEAL(outputFrame, spellID, amount, overhealing, critical, merged, args, settings)
-		else
-			if UnitName('player') == "Dandraffbal" then
-				print("xCT Needs Some Help: unhandled _HEAL event", args.event)
-			end
-		end
-	end,
+        if args.event == "SPELL_PERIODIC_HEAL" then
+            xCTFormat:SPELL_PERIODIC_HEAL(outputFrame, spellID, amount, overhealing, critical, merged, args, settings)
+        elseif args.event == "SPELL_HEAL" then
+            xCTFormat:SPELL_HEAL(outputFrame, spellID, amount, overhealing, critical, merged, args, settings)
+        else
+            if UnitName('player') == "Dandraffbal" then
+                print("xCT Needs Some Help: unhandled _HEAL event", args.event)
+            end
+        end
+    end,
 
-	["DamageOutgoing"] = function (args)
-		local message
-		local spellName, spellSchool = args.spellName, args.spellSchool
-		local critical, spellID, amount, merged = args.critical, args.spellId, args.amount
-		local isEnvironmental, isSwing, isAutoShot, isDoT = args.prefix == "ENVIRONMENTAL", args.prefix == "SWING", spellID == 75, args.prefix == "SPELL_PERIODIC"
-		local outputFrame, outputColorType = "outgoing"
+    ["DamageOutgoing"] = function (args)
+        local message
+        local spellName, spellSchool = args.spellName, args.spellSchool
+        local critical, spellID, amount, merged = args.critical, args.spellId, args.amount
+        local isEnvironmental, isSwing, isAutoShot, isDoT = args.prefix == "ENVIRONMENTAL", args.prefix == "SWING", spellID == 75, args.prefix == "SPELL_PERIODIC"
+        local outputFrame, outputColorType = "outgoing"
 
-		-- Keep track of spells that go by (Don't track Swings or Environmental damage)
-		if not isEnvironmental and not isSwing and TrackSpells() then x.spellCache.spells[spellID] = true end
+        -- Keep track of spells that go by (Don't track Swings or Environmental damage)
+        if not isEnvironmental and not isSwing and TrackSpells() then x.spellCache.spells[spellID] = true end
 
-		if not ShowDamage() then return end
+        if not ShowDamage() then return end
 
-		-- Check to see if this is a HoT
-		if isDoT and not ShowDots() then return end
+        -- Check to see if this is a HoT
+        if isDoT and not ShowDots() then return end
 
-		if isSwing and not args:IsSourceMyPet() and not args:IsSourceMyVehicle() then
-			if critical and not ShowAutoAttack_Outgoing() then return end
-			if not critical and not ShowAutoAttack_Critical() then return end
-		end
+        if isSwing and not args:IsSourceMyPet() and not args:IsSourceMyVehicle() then
+            if critical and not ShowAutoAttack_Outgoing() then return end
+            if not critical and not ShowAutoAttack_Critical() then return end
+        end
 
-		-- Filter Ougoing Damage Spell or Amount
-		if IsSpellFiltered(spellID) or FilterOutgoingDamage(amount) then return end
+        -- Filter Ougoing Damage Spell or Amount
+        if IsSpellFiltered(spellID) or FilterOutgoingDamage(amount) then return end
 
-		-- Check to see if my pet is doing things
-		if args:IsSourceMyPet() and (not ShowKillCommand() or spellID ~= 34026) then
-			if not ShowPetDamage() then return end
-			if isSwing and not ShowPetAutoAttack_Outgoing() then return end
-			if MergePetAttacks() then
-				local icon = x.GetPetTexture() or ""
-				x:AddSpamMessage(outputFrame, icon, amount, x.db.profile.spells.mergePetColor, 6, nil, "auto", spellID == 34026 and L_KILLCOMMAND or L_AUTOATTACK, "destinationController", args:GetDestinationController())
-				return
-			end
-			if not ShowPetCrits() then
-				critical = nil -- stupid spam fix for hunter pets
-			end
-			if isSwing then
-				spellID = 0 -- this will get fixed later
-			end
-		end
+        -- Check to see if my pet is doing things
+        if args:IsSourceMyPet() and (not ShowKillCommand() or spellID ~= 34026) then
+            if not ShowPetDamage() then return end
+            if isSwing and not ShowPetAutoAttack_Outgoing() then return end
+            if MergePetAttacks() then
+                local icon = x.GetPetTexture() or ""
+                x:AddSpamMessage(outputFrame, icon, amount, x.db.profile.spells.mergePetColor, 6, nil, "auto", spellID == 34026 and L_KILLCOMMAND or L_AUTOATTACK, "destinationController", args:GetDestinationController())
+                return
+            end
+            if not ShowPetCrits() then
+                critical = nil -- stupid spam fix for hunter pets
+            end
+            if isSwing then
+                spellID = 0 -- this will get fixed later
+            end
+        end
 
-		if args:IsSourceMyVehicle() then
-			if not ShowVehicleDamage() then return end
-			if isSwing and not ShowPetAutoAttack_Outgoing() then return end -- for BM's second pet, Hati
-			if not ShowPetCrits() then
-				critical = nil -- stupid spam fix for hunter pets
-			end
-			if isSwing then
-				spellID = 0 -- this will get fixed later
-			end
-		end
+        if args:IsSourceMyVehicle() then
+            if not ShowVehicleDamage() then return end
+            if isSwing and not ShowPetAutoAttack_Outgoing() then return end -- for BM's second pet, Hati
+            if not ShowPetCrits() then
+                critical = nil -- stupid spam fix for hunter pets
+            end
+            if isSwing then
+                spellID = 0 -- this will get fixed later
+            end
+        end
 
-		-- Check for Critical Swings
-		if critical then
-			if (isSwing or isAutoShot) and ShowAutoAttack_Critical() then
-				outputFrame = 'critical'
-			elseif not isSwing and not isAutoShot then
-				outputFrame = 'critical'
-			end
-		end
+        -- Check for Critical Swings
+        if critical then
+            if (isSwing or isAutoShot) and ShowAutoAttack_Critical() then
+                outputFrame = 'critical'
+            elseif not isSwing and not isAutoShot then
+                outputFrame = 'critical'
+            end
+        end
 
-		-- Lookup the color
-		if isSwing or isAutoShot then
-			outputColorType = critical and 'meleeCrit' or 'melee'
-		end
+        -- Lookup the color
+        if isSwing or isAutoShot then
+            outputColorType = critical and 'meleeCrit' or 'melee'
+        end
 
-		local outputColor = x.GetSpellSchoolColor(spellSchool, outputColorType)
+        local outputColor = x.GetSpellSchoolColor(spellSchool, outputColorType)
 
-		if (isSwing or isAutoShot) and MergeMeleeSwings() then
-			merged = true
-			if outputFrame == "critical" then
-				if MergeCriticalsByThemselves() then
-					x:AddSpamMessage(outputFrame, spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
-					return
-				elseif MergeCriticalsWithOutgoing() then
-					x:AddSpamMessage("outgoing", spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
-				elseif MergeHideMergedCriticals() then
-					x:AddSpamMessage("outgoing", spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
-					return
-				end
-			else
-				x:AddSpamMessage(outputFrame, spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
-				return
-			end
-		elseif not isSwing and not isAutoShot and MergeSpells() then
-			merged = true
-			if critical then
-				if MergeCriticalsByThemselves() then
-					x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-					return
-				elseif MergeCriticalsWithOutgoing() then
-					x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-				elseif MergeHideMergedCriticals() then
-					x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-					return
-				end
-			else
-				-- args:GetSourceController() / args:GetDestinationController()
-				x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
-				return
-			end
-		end
+        if (isSwing or isAutoShot) and MergeMeleeSwings() then
+            merged = true
+            if outputFrame == "critical" then
+                if MergeCriticalsByThemselves() then
+                    x:AddSpamMessage(outputFrame, spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
+                    return
+                elseif MergeCriticalsWithOutgoing() then
+                    x:AddSpamMessage("outgoing", spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
+                elseif MergeHideMergedCriticals() then
+                    x:AddSpamMessage("outgoing", spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
+                    return
+                end
+            else
+                x:AddSpamMessage(outputFrame, spellID, amount, outputColor, 6, nil, "auto", L_AUTOATTACK, "destinationController", args:GetDestinationController())
+                return
+            end
+        elseif not isSwing and not isAutoShot and MergeSpells() then
+            merged = true
+            if critical then
+                if MergeCriticalsByThemselves() then
+                    x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                    return
+                elseif MergeCriticalsWithOutgoing() then
+                    x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                elseif MergeHideMergedCriticals() then
+                    x:AddSpamMessage("outgoing", spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                    return
+                end
+            else
+                -- args:GetSourceController() / args:GetDestinationController()
+                x:AddSpamMessage(outputFrame, spellID, amount, outputColor, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "destinationController", args:GetDestinationController())
+                return
+            end
+        end
 
-		if critical and (not (isSwing or isAutoShot) or ShowAutoAttack_Critical()) then
-			settings = x.db.profile.frames['critical']
-			if not (isSwing or isAutoShot) or PrefixAutoAttack_Critical() then
-				message = sformat(format_crit, x.db.profile.frames['critical'].critPrefix,
-				                               x:Abbreviate(amount,'critical'),
-				                               x.db.profile.frames['critical'].critPostfix)
-			else
-				message = x:Abbreviate(amount, 'critical')
-			end
-		else
-			settings = x.db.profile.frames['outgoing']
-			message = x:Abbreviate(amount, 'outgoing')
-		end
+        if critical and (not (isSwing or isAutoShot) or ShowAutoAttack_Critical()) then
+            settings = x.db.profile.frames['critical']
+            if not (isSwing or isAutoShot) or PrefixAutoAttack_Critical() then
+                message = sformat(format_crit, x.db.profile.frames['critical'].critPrefix,
+                                               x:Abbreviate(amount,'critical'),
+                                               x.db.profile.frames['critical'].critPostfix)
+            else
+                message = x:Abbreviate(amount, 'critical')
+            end
+        else
+            settings = x.db.profile.frames['outgoing']
+            message = x:Abbreviate(amount, 'outgoing')
+        end
 
-		-- Add the Partial Miss Types
-		if ShowPartialMisses() then
-			local hasPartialMiss, formattedMessage = GetPartialMiss(args, settings, critical and 'critical' or 'outgoing')
-			if hasPartialMiss then
-				message = message .. formattedMessage
-			end
-		end
+        -- Add the Partial Miss Types
+        if ShowPartialMisses() then
+            local hasPartialMiss, formattedMessage = GetPartialMiss(args, settings, critical and 'critical' or 'outgoing')
+            if hasPartialMiss then
+                message = message .. formattedMessage
+            end
+        end
 
-		-- Add names
-		message = message .. x.formatName(args, settings.names)
+        -- Add names
+        message = message .. x.formatName(args, settings.names)
 
-		-- Add Icons
-		message = x:GetSpellTextureFormatted( spellID,
-		                                      message,
-		     x.db.profile.frames[outputFrame].iconsEnabled and x.db.profile.frames[outputFrame].iconsSize or -1,
-		     x.db.profile.frames[outputFrame].spacerIconsEnabled,
-		     x.db.profile.frames[outputFrame].fontJustify )
+        -- Add Icons
+        message = x:GetSpellTextureFormatted( spellID,
+                                              message,
+             x.db.profile.frames[outputFrame].iconsEnabled and x.db.profile.frames[outputFrame].iconsSize or -1,
+             x.db.profile.frames[outputFrame].spacerIconsEnabled,
+             x.db.profile.frames[outputFrame].fontJustify )
 
-		x:AddMessage(outputFrame, message, outputColor)
-	end,
+        x:AddMessage(outputFrame, message, outputColor)
+    end,
 
-	["DamageIncoming"] = function (args)
-		local message
-		local settings = x.db.profile.frames["damage"]
-		local spellName, spellSchool = args.spellName, args.spellSchool
+    ["DamageIncoming"] = function (args)
+        local message
+        local settings = x.db.profile.frames["damage"]
+        local spellName, spellSchool = args.spellName, args.spellSchool
 
-		-- Keep track of spells that go by
-		if args.spellId and TrackSpells() then x.spellCache.damage[args.spellId] = true end
+        -- Keep track of spells that go by
+        if args.spellId and TrackSpells() then x.spellCache.damage[args.spellId] = true end
 
-		if IsDamageFiltered(args.spellId or false) then return end
+        if IsDamageFiltered(args.spellId or false) then return end
 
-		-- Check for resists
-		if ShowResistances() then
-			if FilterIncomingDamage(args.amount + (args.resisted or 0) + (args.blocked or 0) + (args.absorbed or 0)) then return end
+        -- Check for resists
+        if ShowResistances() then
+            if FilterIncomingDamage(args.amount + (args.resisted or 0) + (args.blocked or 0) + (args.absorbed or 0)) then return end
 
-			local resistedAmount, resistType, color
+            local resistedAmount, resistType, color
 
-			-- Check for resists (full and partials)
-			if (args.resisted or 0) > 0 then
-				resistType, resistedAmount = RESIST, args.amount > 0 and args.resisted
-				color = resistedAmount and 'missTypeResist' or 'missTypeResistPartial'
-			elseif (args.blocked or 0) > 0 then
-				resistType, resistedAmount = BLOCK, args.amount > 0 and args.blocked
-				color = resistedAmount and 'missTypeBlock' or 'missTypeBlockPartial'
-			elseif (args.absorbed or 0) > 0 then
-				resistType, resistedAmount = ABSORB, args.amount > 0 and args.absorbed
-				color = resistedAmount and 'missTypeAbsorb' or 'missTypeAbsorbPartial'
-			end
+            -- Check for resists (full and partials)
+            if (args.resisted or 0) > 0 then
+                resistType, resistedAmount = RESIST, args.amount > 0 and args.resisted
+                color = resistedAmount and 'missTypeResist' or 'missTypeResistPartial'
+            elseif (args.blocked or 0) > 0 then
+                resistType, resistedAmount = BLOCK, args.amount > 0 and args.blocked
+                color = resistedAmount and 'missTypeBlock' or 'missTypeBlockPartial'
+            elseif (args.absorbed or 0) > 0 then
+                resistType, resistedAmount = ABSORB, args.amount > 0 and args.absorbed
+                color = resistedAmount and 'missTypeAbsorb' or 'missTypeAbsorbPartial'
+            end
 
-			if resistType then
-				-- Craft the new message (if is partial)
-				if resistedAmount then
-					-- format_resist: "-%s |c%s(%s %s)|r"
-					color = hexNameColor(x.LookupColorByName(color))
-					message = sformat(format_resist, x:Abbreviate(args.amount, 'damage'), color, resistType, x:Abbreviate(resistedAmount, 'damage'))
-				else
-					-- It was a full resist
-					message = resistType	-- TODO: Add an option to still see how much was reisted on a full resist
-				end
-			end
-		else
-			if FilterIncomingDamage(args.amount) then return end
-		end
+            if resistType then
+                -- Craft the new message (if is partial)
+                if resistedAmount then
+                    -- format_resist: "-%s |c%s(%s %s)|r"
+                    color = hexNameColor(x.LookupColorByName(color))
+                    message = sformat(format_resist, x:Abbreviate(args.amount, 'damage'), color, resistType, x:Abbreviate(resistedAmount, 'damage'))
+                else
+                    -- It was a full resist
+                    message = resistType    -- TODO: Add an option to still see how much was reisted on a full resist
+                end
+            end
+        else
+            if FilterIncomingDamage(args.amount) then return end
+        end
 
-		-- If this is not a resist, then lets format it as normal
-		if not message then
-			-- Format Criticals and also abbreviate values
-			if args.critical then
-				message = sformat(format_crit, x.db.profile.frames['damage'].critPrefix,
-				                               x:Abbreviate(-args.amount, 'damage'),
-				                               x.db.profile.frames['damage'].critPostfix)
-			else
-				message = x:Abbreviate(-args.amount, 'damage')
-			end
-		end
+        -- If this is not a resist, then lets format it as normal
+        if not message then
+            -- Format Criticals and also abbreviate values
+            if args.critical then
+                message = sformat(format_crit, x.db.profile.frames['damage'].critPrefix,
+                                               x:Abbreviate(-args.amount, 'damage'),
+                                               x.db.profile.frames['damage'].critPostfix)
+            else
+                message = x:Abbreviate(-args.amount, 'damage')
+            end
+        end
 
-		local colorOverride
-		if args.spellSchool == 1 then
-			colorOverride = args.critical and 'damageTakenCritical' or 'damageTaken'
-		else
-			colorOverride = args.critical and 'spellDamageTakenCritical' or 'spellDamageTaken'
-		end
+        local colorOverride
+        if args.spellSchool == 1 then
+            colorOverride = args.critical and 'damageTakenCritical' or 'damageTaken'
+        else
+            colorOverride = args.critical and 'spellDamageTakenCritical' or 'spellDamageTaken'
+        end
 
-		if MergeSpells() then
-			x:AddSpamMessage('damage', args.spellId, args.amount, colorOverride, nil, nil, "spellName", spellName, "spellSchool", spellSchool, "sourceController", args:GetSourceController())
-			return
-		end
+        if MergeSpells() then
+            x:AddSpamMessage(
+                'damage',
+                args.spellId,
+                args.amount,
+                colorOverride,
+                nil,
+                nil,
+                "spellName",
+                spellName,
+                "spellSchool",
+                spellSchool,
+                "sourceController",
+                args:GetSourceController()
+            )
+            return
+        end
 
-		-- Add names
-		message = message .. x.formatName(args, settings.names, true)
+        -- Add names
+        message = message .. x.formatName(args, settings.names, true)
 
-		-- Add Icons (Hide Auto Attack icons)
-		if args.prefix ~= "SWING" or ShowIncomingAutoAttackIcons() then
-			message = x:GetSpellTextureFormatted(args.spellId,
-			                                     message,
-			       x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
-			       x.db.profile.frames['damage'].spacerIconsEnabled,
-			       x.db.profile.frames['damage'].fontJustify)
-		else
-			message = x:GetSpellTextureFormatted(nil,
-			                                     message,
-			       x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
-			       x.db.profile.frames['damage'].spacerIconsEnabled,
-			       x.db.profile.frames['damage'].fontJustify)
-		end
+        -- Add Icons (Hide Auto Attack icons)
+        if args.prefix ~= "SWING" or ShowIncomingAutoAttackIcons() then
+            message = x:GetSpellTextureFormatted(args.spellId,
+                                                 message,
+                   x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
+                   x.db.profile.frames['damage'].spacerIconsEnabled,
+                   x.db.profile.frames['damage'].fontJustify)
+        else
+            message = x:GetSpellTextureFormatted(nil,
+                                                 message,
+                   x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
+                   x.db.profile.frames['damage'].spacerIconsEnabled,
+                   x.db.profile.frames['damage'].fontJustify)
+        end
 
-		-- Output message
-		x:AddMessage('damage', message, x.GetSpellSchoolColor(args.spellSchool, colorOverride))
-	end,
+        -- Output message
+        x:AddMessage('damage', message, x.GetSpellSchoolColor(args.spellSchool, colorOverride))
+    end,
 
-	["ShieldIncoming"] = function (args)
-		local buffIndex = x.findBuffIndex("player", args.spellName)
-		if not buffIndex then return end
-		local settings, value = x.db.profile.frames['healing'], select(16, C_UnitAuras.GetBuffDataByIndex("player", buffIndex))
-		if not value or value <= 0 then return end
+    ["ShieldIncoming"] = function (args)
+        local buffIndex = x.findBuffIndex("player", args.spellName)
+        if not buffIndex then return end
+        local settings, value = x.db.profile.frames['healing'], select(16, C_UnitAuras.GetBuffDataByIndex("player", buffIndex))
+        if not value or value <= 0 then return end
 
-		if TrackSpells() then x.spellCache.healing[args.spellId] = true end
+        if TrackSpells() then x.spellCache.healing[args.spellId] = true end
 
-		if IsHealingFiltered(args.spellId) then return end
+        if IsHealingFiltered(args.spellId) then return end
 
-		-- Create the message
-		local message = sformat(format_gain, x:Abbreviate(value, "healing"))
+        -- Create the message
+        local message = sformat(format_gain, x:Abbreviate(value, "healing"))
 
-		message = x:GetSpellTextureFormatted(args.spellId,
-			                                   message,
-			    x.db.profile.frames['healing'].iconsEnabled and x.db.profile.frames['healing'].iconsSize or -1,
+        message = x:GetSpellTextureFormatted(args.spellId,
+                                               message,
+                x.db.profile.frames['healing'].iconsEnabled and x.db.profile.frames['healing'].iconsSize or -1,
           x.db.profile.frames['healing'].spacerIconsEnabled,
-			    x.db.profile.frames['healing'].fontJustify)
+                x.db.profile.frames['healing'].fontJustify)
 
-		-- Add names
-		message = message .. x.formatName(args, settings.names, true)
+        -- Add names
+        message = message .. x.formatName(args, settings.names, true)
 
-		x:AddMessage('healing', message, 'shieldTaken')
-	end,
+        x:AddMessage('healing', message, 'shieldTaken')
+    end,
 
-	["HealingIncoming"] = function (args)
-		local amount, isHoT, spellID = args.amount, args.prefix == "SPELL_PERIODIC", args.spellId
-		local color = isHoT and "healingTakenPeriodic" or args.critical and "healingTakenCritical" or "healingTaken"
-		local settings = x.db.profile.frames["healing"]
+    ["HealingIncoming"] = function (args)
+        local amount, isHoT, spellID = args.amount, args.prefix == "SPELL_PERIODIC", args.spellId
+        local color = isHoT and "healingTakenPeriodic" or args.critical and "healingTakenCritical" or "healingTaken"
+        local settings = x.db.profile.frames["healing"]
 
-		if TrackSpells() then x.spellCache.healing[args.spellId] = true end
+        if TrackSpells() then x.spellCache.healing[args.spellId] = true end
 
-		if IsHealingFiltered(args.spellId) then return end
+        if IsHealingFiltered(args.spellId) then return end
 
-		-- Adjust the amount if the user doesnt want over healing
-		if not ShowOverHealing() then
-			amount = amount - args.overhealing
-		end
+        -- Adjust the amount if the user doesnt want over healing
+        if not ShowOverHealing() then
+            amount = amount - args.overhealing
+        end
 
-		-- Don't show healing that gets absorbed by a debuff or mechanic
-		if HideAbsorbedHealing() then
-			amount = amount - args.absorbed
-		end
+        -- Don't show healing that gets absorbed by a debuff or mechanic
+        if HideAbsorbedHealing() then
+            amount = amount - args.absorbed
+        end
 
-		-- Filter out small amounts
-		if amount <= 0 or FilterIncomingHealing(amount) then return end
+        -- Filter out small amounts
+        if amount <= 0 or FilterIncomingHealing(amount) then return end
 
-		if ShowOnlyMyHeals() and not args.isPlayer then
-			if ShowOnlyMyPetsHeals() and args:IsSourceMyPet() then
-				-- If its the pet, then continue
-			else
-				return
-			end
-		end
+        if ShowOnlyMyHeals() and not args.isPlayer then
+            if ShowOnlyMyPetsHeals() and args:IsSourceMyPet() then
+                -- If its the pet, then continue
+            else
+                return
+            end
+        end
 
-		-- format_gain = "+%s"
-		local message = sformat(format_gain, x:Abbreviate(amount,"healing"))
+        -- format_gain = "+%s"
+        local message = sformat(format_gain, x:Abbreviate(amount,"healing"))
 
-		if MergeIncomingHealing() then
-			x:AddSpamMessage("healing", args.sourceName or "Unknown Source Name", amount, "healingTaken", 5, nil, "sourceGUID", args.sourceGUID, "sourceController", args:GetSourceController())
-		else
-			-- Add names
-			message = message .. x.formatName(args, settings.names, true)
+        if MergeIncomingHealing() then
+            x:AddSpamMessage("healing", args.sourceName or "Unknown Source Name", amount, "healingTaken", 5, nil, "sourceGUID", args.sourceGUID, "sourceController", args:GetSourceController())
+        else
+            -- Add names
+            message = message .. x.formatName(args, settings.names, true)
 
-			-- Add the icon
-			message = x:GetSpellTextureFormatted(args.spellId,
-			                                          message,
-			           x.db.profile.frames['healing'].iconsEnabled and x.db.profile.frames['healing'].iconsSize or -1,
-			           x.db.profile.frames['healing'].spacerIconsEnabled,
-			           x.db.profile.frames['healing'].fontJustify)
+            -- Add the icon
+            message = x:GetSpellTextureFormatted(args.spellId,
+                                                      message,
+                       x.db.profile.frames['healing'].iconsEnabled and x.db.profile.frames['healing'].iconsSize or -1,
+                       x.db.profile.frames['healing'].spacerIconsEnabled,
+                       x.db.profile.frames['healing'].fontJustify)
 
-			x:AddMessage("healing", message, color)
-		end
-	end,
+            x:AddMessage("healing", message, color)
+        end
+    end,
 
-	["AuraIncoming"] = function (args)
+    ["AuraIncoming"] = function (args)
 
-		-- Some useful information about the event
-		local isBuff, isGaining = args.auraType == "BUFF", args.suffix == "_AURA_APPLIED" or args.suffix == "_AURA_APPLIED_DOSE"
+        -- Some useful information about the event
+        local isBuff, isGaining = args.auraType == "BUFF", args.suffix == "_AURA_APPLIED" or args.suffix == "_AURA_APPLIED_DOSE"
 
-		-- Track the aura
-		if TrackSpells() then x.spellCache[isBuff and 'buffs' or 'debuffs'][args.spellName]=true end
+        -- Track the aura
+        if TrackSpells() then x.spellCache[isBuff and 'buffs' or 'debuffs'][args.spellName]=true end
 
-		if isBuff then
-			-- Stop if we're not showing buffs _or_ the spell's name is filtered
-			if not ShowBuffs() or IsBuffFiltered(args.spellName) then return end
-		else -- Aura is debuff
-			-- Stop if we're not showing debuffs _or_ the spell's name is filtered
-			if not ShowDebuffs() or IsDebuffFiltered(args.spellName) then return end
-		end
+        if isBuff then
+            -- Stop if we're not showing buffs _or_ the spell's name is filtered
+            if not ShowBuffs() or IsBuffFiltered(args.spellName) then return end
+        else -- Aura is debuff
+            -- Stop if we're not showing debuffs _or_ the spell's name is filtered
+            if not ShowDebuffs() or IsDebuffFiltered(args.spellName) then return end
+        end
 
-		-- Begin constructing the event message and color
-		local color, message
-		if isGaining then
-			message = sformat(format_gain, args.spellName)
-			color = isBuff and 'buffsGained' or 'debuffsGained'
-		else
-			message = sformat(format_fade, args.spellName)
-			color = isBuff and 'buffsFaded' or 'debuffsFaded'
-		end
+        -- Begin constructing the event message and color
+        local color, message
+        if isGaining then
+            message = sformat(format_gain, args.spellName)
+            color = isBuff and 'buffsGained' or 'debuffsGained'
+        else
+            message = sformat(format_fade, args.spellName)
+            color = isBuff and 'buffsFaded' or 'debuffsFaded'
+        end
 
-		-- Add the icon
-		message = x:GetSpellTextureFormatted(args.spellId,
-		                                          message,
-		           x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
-		           x.db.profile.frames['general'].spacerIconsEnabled,
-		           x.db.profile.frames['general'].fontJustify)
+        -- Add the icon
+        message = x:GetSpellTextureFormatted(args.spellId,
+                                                  message,
+                   x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
+                   x.db.profile.frames['general'].spacerIconsEnabled,
+                   x.db.profile.frames['general'].fontJustify)
 
-		x:AddMessage('general', message, color)
-	end,
+        x:AddMessage('general', message, color)
+    end,
 
-	["KilledUnit"] = function (args)
-		if not ShowPartyKill() then return end
+    ["KilledUnit"] = function (args)
+        if not ShowPartyKill() then return end
 
-		local color = 'killingBlow'
-		if args.destGUID then
-			local class = select(2, GetPlayerInfoByGUID(args.destGUID))
-			if RAID_CLASS_COLORS[class] then
-				color = RAID_CLASS_COLORS[class]
-			end
-		end
+        local color = 'killingBlow'
+        if args.destGUID then
+            local class = select(2, GetPlayerInfoByGUID(args.destGUID))
+            if RAID_CLASS_COLORS[class] then
+                color = RAID_CLASS_COLORS[class]
+            end
+        end
 
-		x:AddMessage('general', sformat(format_dispell, XCT_KILLED, args.destName), color)
-	end,
+        x:AddMessage('general', sformat(format_dispell, XCT_KILLED, args.destName), color)
+    end,
 
-	["InterruptedUnit"] = function (args)
-		if not ShowInterrupts() then return end
+    ["InterruptedUnit"] = function (args)
+        if not ShowInterrupts() then return end
 
-		-- Create and format the message
-		local message = sformat(format_dispell, INTERRUPTED, args.extraSpellName)
+        -- Create and format the message
+        local message = sformat(format_dispell, INTERRUPTED, args.extraSpellName)
 
-		-- Add the icon
-		message = x:GetSpellTextureFormatted(args.extraSpellId,
-		                                          message,
-		           x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
-		           x.db.profile.frames['general'].spacerIconsEnabled,
-		           x.db.profile.frames['general'].fontJustify)
+        -- Add the icon
+        message = x:GetSpellTextureFormatted(args.extraSpellId,
+                                                  message,
+                   x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
+                   x.db.profile.frames['general'].spacerIconsEnabled,
+                   x.db.profile.frames['general'].fontJustify)
 
-		x:AddMessage('general', message, 'interrupts')
-	end,
+        x:AddMessage('general', message, 'interrupts')
+    end,
 
-	["OutgoingMiss"] = function (args)
-		local message, spellId = _G["COMBAT_TEXT_"..args.missType], args.spellId
+    ["OutgoingMiss"] = function (args)
+        local message, spellId = _G["COMBAT_TEXT_"..args.missType], args.spellId
 
-		-- If this is a melee swing, it could also be our pets
-		if args.prefix == 'SWING' then
-			if not ShowAutoAttack_Outgoing() then return end
-			if args:IsSourceMyPet() then
-				spellId = PET_ATTACK_TEXTURE
-			else
-				spellId = 6603
-			end
-		end
+        -- If this is a melee swing, it could also be our pets
+        if args.prefix == 'SWING' then
+            if not ShowAutoAttack_Outgoing() then return end
+            if args:IsSourceMyPet() then
+                spellId = PET_ATTACK_TEXTURE
+            else
+                spellId = 6603
+            end
+        end
 
-		-- Check for filtered immunes
-		if args.missType == "ABSORB" and not ShowAbsorbs() then return end
-		if args.missType == "IMMUNE" and not ShowImmunes() then return end
-		if args.missType ~= "IMMUNE" and not ShowMisses() then return end
+        -- Check for filtered immunes
+        if args.missType == "ABSORB" and not ShowAbsorbs() then return end
+        if args.missType == "IMMUNE" and not ShowImmunes() then return end
+        if args.missType ~= "IMMUNE" and not ShowMisses() then return end
 
-		-- Check if spell is filtered
-		if IsSpellFiltered(spellId) then return end
+        -- Check if spell is filtered
+        if IsSpellFiltered(spellId) then return end
 
-		-- Add Icons
-		message = x:GetSpellTextureFormatted(spellId,
-		                                     message,
-		     x.db.profile.frames['outgoing'].iconsEnabled and x.db.profile.frames['outgoing'].iconsSize or -1,
-		     x.db.profile.frames['outgoing'].spacerIconsEnabled,
-		     x.db.profile.frames['outgoing'].fontJustify)
+        -- Add Icons
+        message = x:GetSpellTextureFormatted(spellId,
+                                             message,
+             x.db.profile.frames['outgoing'].iconsEnabled and x.db.profile.frames['outgoing'].iconsSize or -1,
+             x.db.profile.frames['outgoing'].spacerIconsEnabled,
+             x.db.profile.frames['outgoing'].fontJustify)
 
-		x:AddMessage('outgoing', message, 'misstypesOut')
-	end,
+        x:AddMessage('outgoing', message, 'misstypesOut')
+    end,
 
-	["IncomingMiss"] = function (args)
-		if not ShowMissTypes() then return end
+    ["IncomingMiss"] = function (args)
+        if not ShowMissTypes() then return end
 
-		-- Check if incoming spell is filtered
-		if IsDamageFiltered(args.spellId) then return end
+        -- Check if incoming spell is filtered
+        if IsDamageFiltered(args.spellId) then return end
 
-		local message = _G["COMBAT_TEXT_"..args.missType]
+        local message = _G["COMBAT_TEXT_"..args.missType]
 
-		-- Add Icons
-		message = x:GetSpellTextureFormatted(args.spellId,
-		                                          message,
-		          x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
-		          x.db.profile.frames['damage'].spacerIconsEnabled,
-		          x.db.profile.frames['damage'].fontJustify)
+        -- Add Icons
+        message = x:GetSpellTextureFormatted(args.spellId,
+                                                  message,
+                  x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
+                  x.db.profile.frames['damage'].spacerIconsEnabled,
+                  x.db.profile.frames['damage'].fontJustify)
 
-		x:AddMessage('damage', message, missTypeColorLookup[args.missType] or 'misstypesOut')
-	end,
+        x:AddMessage('damage', message, missTypeColorLookup[args.missType] or 'misstypesOut')
+    end,
 
-	["SpellDispel"] = function (args)
-		if not ShowDispells() then return end
+    ["SpellDispel"] = function (args)
+        if not ShowDispells() then return end
 
-		local color = args.auraType == 'BUFF' and 'dispellBuffs' or 'dispellDebuffs'
-		local message = sformat(format_dispell, XCT_DISPELLED, args.extraSpellName)
+        local color = args.auraType == 'BUFF' and 'dispellBuffs' or 'dispellDebuffs'
+        local message = sformat(format_dispell, XCT_DISPELLED, args.extraSpellName)
 
-		-- Add Icons
-		message = x:GetSpellTextureFormatted(args.extraSpellId,
-		                                          message,
-		           x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
+        -- Add Icons
+        message = x:GetSpellTextureFormatted(args.extraSpellId,
+                                                  message,
+                   x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
                x.db.profile.frames['general'].spacerIconsEnabled,
-		           x.db.profile.frames['general'].fontJustify)
+                   x.db.profile.frames['general'].fontJustify)
 
-		if MergeDispells() then
-			x:AddSpamMessage('general', args.extraSpellName, message, color, 0.5)
-		else
-			x:AddMessage('general', message, color)
-		end
-	end,
+        if MergeDispells() then
+            x:AddSpamMessage('general', args.extraSpellName, message, color, 0.5)
+        else
+            x:AddMessage('general', message, color)
+        end
+    end,
 
-	["SpellStolen"] = function (args)
-		if not ShowDispells() then return end
-		local message = sformat(format_dispell, XCT_STOLE, args.extraSpellName)
+    ["SpellStolen"] = function (args)
+        if not ShowDispells() then return end
+        local message = sformat(format_dispell, XCT_STOLE, args.extraSpellName)
 
-		-- Add Icons
-		message = x:GetSpellTextureFormatted(args.extraSpellId,
-		                                          message,
-		           x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
+        -- Add Icons
+        message = x:GetSpellTextureFormatted(args.extraSpellId,
+                                                  message,
+                   x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
                x.db.profile.frames['general'].spacerIconsEnabled,
-		           x.db.profile.frames['general'].fontJustify)
+                   x.db.profile.frames['general'].fontJustify)
 
-		x:AddMessage('general', message, 'dispellStolen')
-	end,
+        x:AddMessage('general', message, 'dispellStolen')
+    end,
 
-	["SpellEnergize"] = function (args)
-		local amount, energy_type = args.amount, x.POWER_LOOKUP[args.powerType]
-		if not energy_type then 
-		    print('xct: unknown SpellEnergize power type: ' .. args.powerType) 
-		    return 
-		end
-		if not ShowEnergyGains() then return end
-		if FilterPlayerPower(mabs(tonumber(amount))) then return end
-		if IsResourceDisabled( energy_type, amount ) then return end
+    ["SpellEnergize"] = function (args)
+        local amount, energy_type = args.amount, x.POWER_LOOKUP[args.powerType]
+        if not energy_type then 
+            print('xct: unknown SpellEnergize power type: ' .. args.powerType) 
+            return 
+        end
+        if not ShowEnergyGains() then return end
+        if FilterPlayerPower(mabs(tonumber(amount))) then return end
+        if IsResourceDisabled( energy_type, amount ) then return end
 
-		local color, message = nil, x:Abbreviate( amount, "power" )
-		if energy_type == "ECLIPSE" then
-			if amount > 0 then
-				color = x.LookupColorByName("color_ECLIPSE_positive")
-			elseif amount < 0 then
-				color = x.LookupColorByName("color_ECLIPSE_negative")
-			end
-		else
-			color = x.LookupColorByName("color_" .. energy_type )
-		end
+        local color, message = nil, x:Abbreviate( amount, "power" )
+        if energy_type == "ECLIPSE" then
+            if amount > 0 then
+                color = x.LookupColorByName("color_ECLIPSE_positive")
+            elseif amount < 0 then
+                color = x.LookupColorByName("color_ECLIPSE_negative")
+            end
+        else
+            color = x.LookupColorByName("color_" .. energy_type )
+        end
 
-		-- Default Color will be white
-		if not color then
-			color = {1,1,1}
-		end
-		x:AddMessage("power", sformat(format_energy, message, ShowEnergyTypes() and _G[energy_type] or ""), color)
-	end,
+        -- Default Color will be white
+        if not color then
+            color = {1,1,1}
+        end
+        x:AddMessage("power", sformat(format_energy, message, ShowEnergyTypes() and _G[energy_type] or ""), color)
+    end,
 }
 
 local BuffsOrDebuffs = {
-	["_AURA_APPLIED"] = true,
-	["_AURA_REMOVED"] = true,
-	["_AURA_APPLIED_DOSE"] = true,
-	["_AURA_REMOVED_DOSE"] = true,
-	--["_AURA_REFRESH"] = true, -- I dont know how we should support this
+    ["_AURA_APPLIED"] = true,
+    ["_AURA_REMOVED"] = true,
+    ["_AURA_APPLIED_DOSE"] = true,
+    ["_AURA_REMOVED_DOSE"] = true,
+    --["_AURA_REFRESH"] = true, -- I dont know how we should support this
 }
 
 -- List from: http://www.tukui.org/addons/index.php?act=view&id=236
 local AbsorbList = {
-	-- All
-	[187805] = true, -- Etheralus (WoD Legendary Ring)
-	[173260] = true, -- Shield Tronic (Like a health potion from WoD)
-	[64413]  = true, -- Val'anyr, Hammer of Ancient Kings (WotLK Legendary Mace)
-	[82626]  = true, -- Grounded Plasma Shield (Engineer's Belt Enchant)
-	[207472] = true, -- Prydaz, Xavaric's Magnum Opus (Legendary Neck)
+    -- All
+    [187805] = true, -- Etheralus (WoD Legendary Ring)
+    [173260] = true, -- Shield Tronic (Like a health potion from WoD)
+    [64413]  = true, -- Val'anyr, Hammer of Ancient Kings (WotLK Legendary Mace)
+    [82626]  = true, -- Grounded Plasma Shield (Engineer's Belt Enchant)
+    [207472] = true, -- Prydaz, Xavaric's Magnum Opus (Legendary Neck)
 
-	-- Coming Soon (Delicious Cake!) Trinket
-	--[231290] = true, -- TODO: Figure out which one is correct
-	[225723] = true, -- Both are Delicious Cake! from item:140793
+    -- Coming Soon (Delicious Cake!) Trinket
+    --[231290] = true, -- TODO: Figure out which one is correct
+    [225723] = true, -- Both are Delicious Cake! from item:140793
 
-	-- Coming Soon (Royal Dagger Haft, item:140791)
-	-- Sooooo I dont think this one is going to be trackable... we will see when i can get some logs!
-	--[225720] = true, -- TODO: Figure out which is the real one
-	--[229457] = true, -- Sands of Time (From the Royal Dagger Haft tinket) (Its probably this one)
-	--[229333] = true, -- Sands of Time (From the Royal Dagger Haft tinket)
-	--[225124] = true, -- Sands of Time (From the Royal Dagger Haft tinket)
+    -- Coming Soon (Royal Dagger Haft, item:140791)
+    -- Sooooo I dont think this one is going to be trackable... we will see when i can get some logs!
+    --[225720] = true, -- TODO: Figure out which is the real one
+    --[229457] = true, -- Sands of Time (From the Royal Dagger Haft tinket) (Its probably this one)
+    --[229333] = true, -- Sands of Time (From the Royal Dagger Haft tinket)
+    --[225124] = true, -- Sands of Time (From the Royal Dagger Haft tinket)
 
-	-- Coming Soon -- Animated Exoskeleton (Trinket, Item: 140789)
-	[225033] = true, -- Living Carapace (Needs to be verified)
+    -- Coming Soon -- Animated Exoskeleton (Trinket, Item: 140789)
+    [225033] = true, -- Living Carapace (Needs to be verified)
 
-	-- Coming Soon -- Infernal Contract (Trinket, Item: 140807)
-	[225140] = true, -- Infernal Contract (Needs to be verified)
+    -- Coming Soon -- Infernal Contract (Trinket, Item: 140807)
+    [225140] = true, -- Infernal Contract (Needs to be verified)
 
 
 
-	-- Legion Trinkets
-	[221878] = true, -- Buff: Spirit Fragment        - Trinket[138222]: Vial of Nightmare Fog
-	[215248] = true, -- Buff: Shroud of the Naglfar  - Trinket[133645]: Naglfar Fare
-	[214366] = true, -- Buff: Crystalline Body       - Trinket[137338]: Shard of Rokmora
-	[214423] = true, -- Buff: Stance of the Mountain - Trinket[137344]: Talisman of the Cragshaper
-	[214971] = true, -- Buff: Gaseous Bubble         - Trinket[137369]: Giant Ornamental Pearl
-	[222479] = true, -- Buff: Shadowy Reflection     - Trinket[138225]: Phantasmal Echo
+    -- Legion Trinkets
+    [221878] = true, -- Buff: Spirit Fragment        - Trinket[138222]: Vial of Nightmare Fog
+    [215248] = true, -- Buff: Shroud of the Naglfar  - Trinket[133645]: Naglfar Fare
+    [214366] = true, -- Buff: Crystalline Body       - Trinket[137338]: Shard of Rokmora
+    [214423] = true, -- Buff: Stance of the Mountain - Trinket[137344]: Talisman of the Cragshaper
+    [214971] = true, -- Buff: Gaseous Bubble         - Trinket[137369]: Giant Ornamental Pearl
+    [222479] = true, -- Buff: Shadowy Reflection     - Trinket[138225]: Phantasmal Echo
 
-	-- Death Knight
-	[48707] = true,  -- Anti-Magic Shield
-	[77535] = true,  -- Blood Shield
-	[116888] = true, -- Purgatory
-	[219809] = true, -- Tombstone
+    -- Death Knight
+    [48707] = true,  -- Anti-Magic Shield
+    [77535] = true,  -- Blood Shield
+    [116888] = true, -- Purgatory
+    [219809] = true, -- Tombstone
 
-	-- Demon Hunter
-	[227225] = true, -- Soul Barrier
+    -- Demon Hunter
+    [227225] = true, -- Soul Barrier
 
-	-- Mage
-	[11426] = true,  -- Ice Barrier
+    -- Mage
+    [11426] = true,  -- Ice Barrier
 
-	-- Monk
-	[116849] = true, -- Life Cocoon
+    -- Monk
+    [116849] = true, -- Life Cocoon
 
-	-- Paladin
-	[203538] = true, -- Greater Blessing of Kings
-	[185676] = true, -- Protection Paladin T18 - 2 piece
-	[184662] = true, -- Shield of Vengeance
+    -- Paladin
+    [203538] = true, -- Greater Blessing of Kings
+    [185676] = true, -- Protection Paladin T18 - 2 piece
+    [184662] = true, -- Shield of Vengeance
 
-	--Priest
-	[152118] = true, -- Clarity of Will
-	[17] = true,     -- Power Word: Shield
+    --Priest
+    [152118] = true, -- Clarity of Will
+    [17] = true,     -- Power Word: Shield
 
-	-- Shaman
-	[145378] = true, -- Shaman T16 - 2 piece
-	[114893] = true, -- Stone Bulwark
+    -- Shaman
+    [145378] = true, -- Shaman T16 - 2 piece
+    [114893] = true, -- Stone Bulwark
 
-	-- Warlock
-	[108416] = true, -- Dark Pact
-	[108366] = true, -- Soul Leech
+    -- Warlock
+    [108416] = true, -- Dark Pact
+    [108366] = true, -- Soul Leech
 
-	-- Warrior
-	[190456] = true, -- Ignore Pain
-	[112048] = true, -- Shield Barrier
+    -- Warrior
+    [190456] = true, -- Ignore Pain
+    [112048] = true, -- Shield Barrier
 }
 
 function x.CombatLogEvent (args)
-	-- Is the source someone we care about?
-	if args.isPlayer or args:IsSourceMyVehicle() or ShowPetDamage() and args:IsSourceMyPet() then
-		if args.suffix == "_HEAL" then
-			CombatEventHandlers.HealingOutgoing(args)
+    -- Is the source someone we care about?
+    if args.isPlayer or args:IsSourceMyVehicle() or ShowPetDamage() and args:IsSourceMyPet() then
+        if args.suffix == "_HEAL" then
+            CombatEventHandlers.HealingOutgoing(args)
 
-		elseif args.suffix == "_DAMAGE" then
-			CombatEventHandlers.DamageOutgoing(args)
+        elseif args.suffix == "_DAMAGE" then
+            CombatEventHandlers.DamageOutgoing(args)
 
-		elseif args.suffix == '_MISSED' then
-			CombatEventHandlers.OutgoingMiss(args)
+        elseif args.suffix == '_MISSED' then
+            CombatEventHandlers.OutgoingMiss(args)
 
-		elseif args.event == 'PARTY_KILL' then
-			CombatEventHandlers.KilledUnit(args)
+        elseif args.event == 'PARTY_KILL' then
+            CombatEventHandlers.KilledUnit(args)
 
-		elseif args.event == 'SPELL_INTERRUPT' then
-			CombatEventHandlers.InterruptedUnit(args)
+        elseif args.event == 'SPELL_INTERRUPT' then
+            CombatEventHandlers.InterruptedUnit(args)
 
-		elseif args.event == 'SPELL_DISPEL' then
-			CombatEventHandlers.SpellDispel(args)
+        elseif args.event == 'SPELL_DISPEL' then
+            CombatEventHandlers.SpellDispel(args)
 
-		elseif args.event == 'SPELL_STOLEN' then
-			CombatEventHandlers.SpellStolen(args)
+        elseif args.event == 'SPELL_STOLEN' then
+            CombatEventHandlers.SpellStolen(args)
 
-		elseif (args.suffix == "_AURA_APPLIED" or args.suffix == "_AURA_REFRESH") and AbsorbList[args.spellId] then
-			CombatEventHandlers.ShieldOutgoing(args)
+        elseif (args.suffix == "_AURA_APPLIED" or args.suffix == "_AURA_REFRESH") and AbsorbList[args.spellId] then
+            CombatEventHandlers.ShieldOutgoing(args)
 
-		elseif args.suffix == "_ENERGIZE" then
-			CombatEventHandlers.SpellEnergize(args)
+        elseif args.suffix == "_ENERGIZE" then
+            CombatEventHandlers.SpellEnergize(args)
 
-		end
-	end
+        end
+    end
 
-	-- Is the destination someone we care about?
-	if args.atPlayer or args:IsDestinationMyVehicle() then
-		if args.suffix == "_HEAL" then
-			CombatEventHandlers.HealingIncoming(args)
+    -- Is the destination someone we care about?
+    if args.atPlayer or args:IsDestinationMyVehicle() then
+        if args.suffix == "_HEAL" then
+            CombatEventHandlers.HealingIncoming(args)
 
-		elseif args.suffix == "_DAMAGE" then
-			CombatEventHandlers.DamageIncoming(args)
+        elseif args.suffix == "_DAMAGE" then
+            CombatEventHandlers.DamageIncoming(args)
 
-		elseif args.suffix == "_MISSED" then
-			CombatEventHandlers.IncomingMiss(args)
+        elseif args.suffix == "_MISSED" then
+            CombatEventHandlers.IncomingMiss(args)
 
-		elseif args.event == 'SPELL_DISPEL' then
-			if ShowDispells() then
-				local message = args.sourceName .. " dispelled:"
+        elseif args.event == 'SPELL_DISPEL' then
+            if ShowDispells() then
+                local message = args.sourceName .. " dispelled:"
 
-				if GetLocale() == "koKR" then message = args.sourceName .. " 무효화:" end
+                if GetLocale() == "koKR" then message = args.sourceName .. " 무효화:" end
 
-				message = x:GetSpellTextureFormatted(args.extraSpellId,
-				                                     message,
-				      x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
-				      x.db.profile.frames['general'].spacerIconsEnabled,
-				      x.db.profile.frames['general'].fontJustify)
+                message = x:GetSpellTextureFormatted(args.extraSpellId,
+                                                     message,
+                      x.db.profile.frames['general'].iconsEnabled and x.db.profile.frames['general'].iconsSize or -1,
+                      x.db.profile.frames['general'].spacerIconsEnabled,
+                      x.db.profile.frames['general'].fontJustify)
 
-				x:AddMessage('general', message, "dispellDebuffs")
-			end
+                x:AddMessage('general', message, "dispellDebuffs")
+            end
 
-		elseif (args.suffix == "_AURA_APPLIED" or args.suffix == "_AURA_REFRESH") and AbsorbList[args.spellId] then
-			CombatEventHandlers.ShieldIncoming(args)
-		end
-	end
+        elseif (args.suffix == "_AURA_APPLIED" or args.suffix == "_AURA_REFRESH") and AbsorbList[args.spellId] then
+            CombatEventHandlers.ShieldIncoming(args)
+        end
+    end
 
-	-- Player Auras
-	if args.atPlayer and BuffsOrDebuffs[args.suffix] then
-		CombatEventHandlers.AuraIncoming(args)
-	end
+    -- Player Auras
+    if args.atPlayer and BuffsOrDebuffs[args.suffix] then
+        CombatEventHandlers.AuraIncoming(args)
+    end
 end
 
 function x.findBuffIndex(unitName, spellName)
-	for i = 1, 40 do
+    for i = 1, 40 do
 
-		-- TODO: Keep if we want to change this to find SpellID index
-		-- buffName, _, _, _, _, _, _, _, _ , spellId = C_UnitAuras.GetBuffDataByIndex(unitName, i)
+        -- TODO: Keep if we want to change this to find SpellID index
+        -- buffName, _, _, _, _, _, _, _, _ , spellId = C_UnitAuras.GetBuffDataByIndex(unitName, i)
 
-		if C_UnitAuras.GetBuffDataByIndex(unitName, i) == spellName then
-			return i
-		end
-	end
-	return false
+        if C_UnitAuras.GetBuffDataByIndex(unitName, i) == spellName then
+            return i
+        end
+    end
+    return false
 end

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -1582,7 +1582,6 @@ local CombatEventHandlers = {
         end
 
         if MergeSpells() then
-          print('DamageIncoming ' .. args.spellId .. ' ' .. args.amount)
             x:AddSpamMessage(
                 'damage',
                 args.spellId,

--- a/modules/combattext.lua
+++ b/modules/combattext.lua
@@ -245,7 +245,6 @@ local function HideAbsorbedHealing() return x.db.profile.frames["healing"].hideA
 local function ShowEnergyGains() return x.db.profile.frames["power"].showEnergyGains end
 local function ShowPeriodicEnergyGains() return x.db.profile.frames["power"].showPeriodicEnergyGains end
 local function ShowEnergyTypes() return x.db.profile.frames["power"].showEnergyType end
-local function ShowIncomingAutoAttackIcons() return x.db.profile.frames["damage"].iconsEnabledAutoAttack end
 
 -- These settings are for the overhealing that the player does
 local function ShowOutgoingOverHealing() return x.db.profile.frames["outgoing"].enableOverhealing end
@@ -562,6 +561,10 @@ function x.OnCombatTextEvent(self, event, ...)
   end
 end
 
+function x:ShowIncomingAutoAttackIcons()
+    return x.db.profile.frames["damage"].iconsEnabledAutoAttack
+end
+
 --[=====================================================[
  AddOn:GetSpellTextureFormatted(
     spellID,        [number] - The spell ID you want the icon for
@@ -576,27 +579,23 @@ end
   Returns:
     message,     [string] - the message contains the formatted icon
 
-    Formats an icon quickly for use when outputing to a combat text frame.
+    Formats an icon quickly for use when outputting to a combat text frame.
 --]=====================================================]
 function x:GetSpellTextureFormatted( spellID, message, iconSize, showInvisibleIcon, justify, strColor, mergeOverride, entries )
-  local icon = x.BLANK_ICON
   strColor = strColor or format_strcolor_white
-  if spellID == 0 then
-    icon = PET_ATTACK_TEXTURE
-  elseif type(spellID) == 'string' then
-    icon = spellID
-  elseif spellID == 6603 then
-    -- Auto attack
-    icon = x.BLANK_ICON
-  else
-    icon = C_Spell.GetSpellTexture( addon.merge2h[spellID] or spellID ) or x.BLANK_ICON
-  end
 
-  if iconSize < 1 then
-    icon = x.BLANK_ICON
-  else
-    -- always show unless we specify enableIcons to be off (overriding iconSize to be -1)
-    showInvisibleIcon = true
+  local icon = x.BLANK_ICON
+  if iconSize >= 1 then
+      -- always show unless we specify enableIcons to be off (overriding iconSize to be -1)
+      showInvisibleIcon = true
+
+      if spellID == 0 then
+          icon = PET_ATTACK_TEXTURE
+      elseif type(spellID) == 'string' then
+          icon = spellID
+      else
+          icon = C_Spell.GetSpellTexture( addon.merge2h[spellID] or spellID ) or x.BLANK_ICON
+      end
   end
 
   if mergeOverride then
@@ -1603,18 +1602,22 @@ local CombatEventHandlers = {
         message = message .. x.formatName(args, settings.names, true)
 
         -- Add Icons (Hide Auto Attack icons)
-        if args.prefix ~= "SWING" or ShowIncomingAutoAttackIcons() then
-            message = x:GetSpellTextureFormatted(args.spellId,
-                                                 message,
-                   x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
-                   x.db.profile.frames['damage'].spacerIconsEnabled,
-                   x.db.profile.frames['damage'].fontJustify)
+        if args.prefix ~= "SWING" or x:ShowIncomingAutoAttackIcons() then
+            message = x:GetSpellTextureFormatted(
+                args.spellId,
+                message,
+                x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
+                x.db.profile.frames['damage'].spacerIconsEnabled,
+                x.db.profile.frames['damage'].fontJustify
+            )
         else
-            message = x:GetSpellTextureFormatted(nil,
-                                                 message,
-                   x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
-                   x.db.profile.frames['damage'].spacerIconsEnabled,
-                   x.db.profile.frames['damage'].fontJustify)
+            message = x:GetSpellTextureFormatted(
+                nil,
+                message,
+                x.db.profile.frames['damage'].iconsEnabled and x.db.profile.frames['damage'].iconsSize or -1,
+                x.db.profile.frames['damage'].spacerIconsEnabled,
+                x.db.profile.frames['damage'].fontJustify
+            )
         end
 
         -- Output message

--- a/modules/frames.lua
+++ b/modules/frames.lua
@@ -21,7 +21,7 @@ local LSM = LibStub("LibSharedMedia-3.0");
 
 -- Setup up values
 local ssub, sformat, sgsub, pairs, tonumber, tostring, math, unpack, print, type, mfloor, random, table_insert, format, _G, select
-	= string.sub, string.format, string.gsub, pairs, tonumber, tostring, math, unpack, print, type, math.floor, math.random, table.insert, string.format, _G, select
+    = string.sub, string.format, string.gsub, pairs, tonumber, tostring, math, unpack, print, type, math.floor, math.random, table.insert, string.format, _G, select
 
 -- Start the Random Machine!
 random(time()); random(); random(time())
@@ -34,254 +34,254 @@ x.frames = { }
 
 -- Static frame lookup
 local frameIndex = {
-	[1] = "general",
-	[2] = "outgoing",
-	[3] = "critical",
-	[4] = "damage",
-	[5] = "healing",
-	[6] = "power",
-	[7] = "procs",
-	[8] = "loot",
-	--[9] = "class",	-- this is not used by redirection
+    [1] = "general",
+    [2] = "outgoing",
+    [3] = "critical",
+    [4] = "damage",
+    [5] = "healing",
+    [6] = "power",
+    [7] = "procs",
+    [8] = "loot",
+    --[9] = "class",    -- this is not used by redirection
 }
 
 -- Static Title Lookup
 x.FrameTitles = {
-	["general"]		= "General",					-- COMBAT_TEXT_LABEL,
-	["outgoing"]	= "Outgoing",					-- SCORE_DAMAGE_DONE.." / "..SCORE_HEALING_DONE,
-	["critical"]	= "Outgoing (Criticals)",		-- TEXT_MODE_A_STRING_RESULT_CRITICAL:gsub("%(", ""):gsub("%)", ""), -- "(Critical)" --> "Critical"
-	["damage"]		= "Damage (Incoming)",			-- DAMAGE,
-	["healing"]		= "Healing (Incoming)",			-- SHOW_COMBAT_HEALING,
-	["power"]		= "Class Power",				-- COMBAT_TEXT_SHOW_ENERGIZE_TEXT,
-	--["class"]		= "Combo",						-- COMBAT_TEXT_SHOW_COMBO_POINTS_TEXT,
-	["procs"]		= "Special Effects (Procs)",	-- COMBAT_TEXT_SHOW_REACTIVES_TEXT,
-	["loot"]		= "Loot & Money",				-- LOOT,
+    ["general"]        = "General",                    -- COMBAT_TEXT_LABEL,
+    ["outgoing"]    = "Outgoing",                    -- SCORE_DAMAGE_DONE.." / "..SCORE_HEALING_DONE,
+    ["critical"]    = "Outgoing (Criticals)",        -- TEXT_MODE_A_STRING_RESULT_CRITICAL:gsub("%(", ""):gsub("%)", ""), -- "(Critical)" --> "Critical"
+    ["damage"]        = "Damage (Incoming)",            -- DAMAGE,
+    ["healing"]        = "Healing (Incoming)",            -- SHOW_COMBAT_HEALING,
+    ["power"]        = "Class Power",                -- COMBAT_TEXT_SHOW_ENERGIZE_TEXT,
+    --["class"]        = "Combo",                        -- COMBAT_TEXT_SHOW_COMBO_POINTS_TEXT,
+    ["procs"]        = "Special Effects (Procs)",    -- COMBAT_TEXT_SHOW_REACTIVES_TEXT,
+    ["loot"]        = "Loot & Money",                -- LOOT,
 }
 
 local frameTitles = x.FrameTitles
 
 local function autoClearFrame_OnUpdate(self, elasped)
-	if not self.last then self.last = 0 end
-	self.last = self.last + elasped
+    if not self.last then self.last = 0 end
+    self.last = self.last + elasped
 
-	if self.last > 4 then
-		x:Clear(self.name)
-		self:SetScript("OnUpdate", nil)
-		self.f.timer = nil
-	end
+    if self.last > 4 then
+        x:Clear(self.name)
+        self:SetScript("OnUpdate", nil)
+        self.f.timer = nil
+    end
 end
 
 -- Function to allow users to scroll a frame with mouseover
 local function Frame_OnMouseWheel(self, delta)
-	if delta > 0 then
-		self:ScrollUp()
-	elseif delta < 0 then
-		self:ScrollDown()
-	end
+    if delta > 0 then
+        self:ScrollUp()
+    elseif delta < 0 then
+        self:ScrollDown()
+    end
 end
 
 local function Frame_SendTestMessage_OnUpdate(self, e)
-	if self.frameName == "class" then
-		x:AddMessage(self.frameName, "0", self.settings.fontColor or {1,1,0})
+    if self.frameName == "class" then
+        x:AddMessage(self.frameName, "0", self.settings.fontColor or {1,1,0})
 
-		if not self.timer then
-			self.timer = CreateFrame("FRAME")
-			self.timer.name = self.frameName
-			self.timer.f = self
-			self.timer:SetScript("OnUpdate", autoClearFrame_OnUpdate)
-		else
-			self.timer.last = 0
-		end
-	else
-		x:AddMessage(self.frameName, self.frameName.." test message", self.settings.fontColor or {1,1,1})
-	end
+        if not self.timer then
+            self.timer = CreateFrame("FRAME")
+            self.timer.name = self.frameName
+            self.timer.f = self
+            self.timer:SetScript("OnUpdate", autoClearFrame_OnUpdate)
+        else
+            self.timer.last = 0
+        end
+    else
+        x:AddMessage(self.frameName, self.frameName.." test message", self.settings.fontColor or {1,1,1})
+    end
 
-	if x.testing then
-		self.lastUpdate = 0
-		self:SetScript("OnUpdate", x.TestMoreUpdate)
-	else
-		self:SetScript("OnUpdate", nil)
-	end
+    if x.testing then
+        self.lastUpdate = 0
+        self:SetScript("OnUpdate", x.TestMoreUpdate)
+    else
+        self:SetScript("OnUpdate", nil)
+    end
 end
 
 function x:GetFrame(framename, bypassUpdate)
-	if not bypassUpdate then
-		x:UpdateFrames(specificFrame)
-	end
-	return x.frames[framename]
+    if not bypassUpdate then
+        x:UpdateFrames(specificFrame)
+    end
+    return x.frames[framename]
 end
 
 -- =====================================================
 -- AddOn:UpdateFrames(
---		specificFrame,	[string] - (Optional) the framename
---	)
---		If you specify a specificFrame then only that
---	frame will be updated, otherwise all the frames will
---	be updated.
+--        specificFrame,    [string] - (Optional) the framename
+--    )
+--        If you specify a specificFrame then only that
+--    frame will be updated, otherwise all the frames will
+--    be updated.
 -- =====================================================
 function x:UpdateFrames(specificFrame)
 
-	-- Update Head Numbers and FCT Font Settings
-	if build < 70000 then
-		if not specificFrame then x:UpdateBlizzardFCT() end
-	end
+    -- Update Head Numbers and FCT Font Settings
+    if build < 70000 then
+        if not specificFrame then x:UpdateBlizzardFCT() end
+    end
 
-	-- Update the frames
-	for framename, settings in pairs(x.db.profile.frames) do
-		if specificFrame and specificFrame == framename or not specificFrame then
-			local f = nil
+    -- Update the frames
+    for framename, settings in pairs(x.db.profile.frames) do
+        if specificFrame and specificFrame == framename or not specificFrame then
+            local f = nil
 
-			-- Create the frame (or retrieve it)
-			if x.frames[framename] then
-				f = x.frames[framename]
-			else
-				f = CreateFrame("ScrollingMessageFrame", "xCT_Plus"..framename.."Frame", UIParent, "BackdropTemplate")
-				f:SetSpacing(2)
-				f:ClearAllPoints()
-				f:SetMovable(true)
-				f:SetResizable(true)
-				--f:SetMinResize(64, 32)
-				--f:SetMaxResize(768, 768)
-				f:SetClampedToScreen(true)
-				f:SetShadowColor(0, 0, 0, 0)
+            -- Create the frame (or retrieve it)
+            if x.frames[framename] then
+                f = x.frames[framename]
+            else
+                f = CreateFrame("ScrollingMessageFrame", "xCT_Plus"..framename.."Frame", UIParent, "BackdropTemplate")
+                f:SetSpacing(2)
+                f:ClearAllPoints()
+                f:SetMovable(true)
+                f:SetResizable(true)
+                --f:SetMinResize(64, 32)
+                --f:SetMaxResize(768, 768)
+                f:SetClampedToScreen(true)
+                f:SetShadowColor(0, 0, 0, 0)
 
-				f.sizing = CreateFrame("Frame", "xCT_Plus"..framename.."SizingFrame", f)
-				f.sizing.parent = f
-				f.sizing:SetHeight(16)
-				f.sizing:SetWidth(16)
-				f.sizing:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -1, 1)
-				f.sizing:Hide()
+                f.sizing = CreateFrame("Frame", "xCT_Plus"..framename.."SizingFrame", f)
+                f.sizing.parent = f
+                f.sizing:SetHeight(16)
+                f.sizing:SetWidth(16)
+                f.sizing:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -1, 1)
+                f.sizing:Hide()
 
-				f.moving = CreateFrame("Frame", "xCT_Plus"..framename.."MovingFrame", f)
-				f.moving.parent = f
-				f.moving:SetPoint("TOPLEFT", f, "TOPLEFT", 1, -1)
-				f.moving:SetPoint("TOPRIGHT", f, "TOPRIGHT", -1, -21)
-				f.moving:SetHeight(20)
-				f.moving:Hide()
+                f.moving = CreateFrame("Frame", "xCT_Plus"..framename.."MovingFrame", f)
+                f.moving.parent = f
+                f.moving:SetPoint("TOPLEFT", f, "TOPLEFT", 1, -1)
+                f.moving:SetPoint("TOPRIGHT", f, "TOPRIGHT", -1, -21)
+                f.moving:SetHeight(20)
+                f.moving:Hide()
 
-				x.frames[framename] = f
-			end
+                x.frames[framename] = f
+            end
 
-			f.frameName = framename
-			f.settings = settings
+            f.frameName = framename
+            f.settings = settings
 
-			-- Frame Strata
-			if x.configuring then
-				f:SetFrameStrata("FULLSCREEN_DIALOG")
-			else
-				f:SetFrameStrata(ssub(x.db.profile.frameSettings.frameStrata, 2))
-			end
+            -- Frame Strata
+            if x.configuring then
+                f:SetFrameStrata("FULLSCREEN_DIALOG")
+            else
+                f:SetFrameStrata(ssub(x.db.profile.frameSettings.frameStrata, 2))
+            end
 
-			-- Set the position
-			if settings.enabledFrame then
-				f:SetWidth(settings.Width)
-				f:SetHeight(settings.Height)
+            -- Set the position
+            if settings.enabledFrame then
+                f:SetWidth(settings.Width)
+                f:SetHeight(settings.Height)
 
-				-- WoW's default movement from changing the anchor
-				local point, relativeTo, relativePoint, xOfs, yOfs = unpack(f:GetNumPoints() > 0 and {f:GetPoint(0)} or {})
+                -- WoW's default movement from changing the anchor
+                local point, relativeTo, relativePoint, xOfs, yOfs = unpack(f:GetNumPoints() > 0 and {f:GetPoint(0)} or {})
 
-				-- If the point is not center, then something dirty happened... clean it up
-				if point and point ~= "CENTER" then
-					-- Calculate the center of the screen
-					local ResX, ResY = GetScreenWidth(), GetScreenHeight()
-					local midX, midY = ResX / 2, ResY / 2
+                -- If the point is not center, then something dirty happened... clean it up
+                if point and point ~= "CENTER" then
+                    -- Calculate the center of the screen
+                    local ResX, ResY = GetScreenWidth(), GetScreenHeight()
+                    local midX, midY = ResX / 2, ResY / 2
 
-					-- Calculate the Top/Left of a frame relative to the center
-					local left, top = mfloor(f:GetLeft() - midX + .5), mfloor(f:GetTop() - midY + .5)
+                    -- Calculate the Top/Left of a frame relative to the center
+                    local left, top = mfloor(f:GetLeft() - midX + .5), mfloor(f:GetTop() - midY + .5)
 
-					-- Calculate get the center of the screen from the left/top
-					local x = mfloor(left + (f:GetWidth() / 2) + .5)
-					local y = mfloor(top - (f:GetHeight() / 2) + .5)
+                    -- Calculate get the center of the screen from the left/top
+                    local x = mfloor(left + (f:GetWidth() / 2) + .5)
+                    local y = mfloor(top - (f:GetHeight() / 2) + .5)
 
-					f:ClearAllPoints()
-					f:SetPoint("CENTER", x, y)
-				else
-					f:ClearAllPoints()
-					f:SetPoint("CENTER", settings.X, settings.Y)
-				end
-			end
+                    f:ClearAllPoints()
+                    f:SetPoint("CENTER", x, y)
+                else
+                    f:ClearAllPoints()
+                    f:SetPoint("CENTER", settings.X, settings.Y)
+                end
+            end
 
-			-- For keeping the frame on the screen
-			--f:SetClampRectInsets(0, 0, settings.fontSize, 0)
+            -- For keeping the frame on the screen
+            --f:SetClampRectInsets(0, 0, settings.fontSize, 0)
 
-			-- Frame Alpha
-			--f:SetAlpha(settings.alpha / 100)
+            -- Frame Alpha
+            --f:SetAlpha(settings.alpha / 100)
 
-			-- NOTE: Setting the frame alpha this way still works... but it
-			-- doesn't apply to string texture children. FontString:SetAlpha
-			-- still works normally. Added bonus of not fading the frame
-			-- when we are configuring.
+            -- NOTE: Setting the frame alpha this way still works... but it
+            -- doesn't apply to string texture children. FontString:SetAlpha
+            -- still works normally. Added bonus of not fading the frame
+            -- when we are configuring.
 
-			-- Insert Direction
-			if settings.insertText then
-				f:SetInsertMode(settings.insertText == 'top' and SCROLLING_MESSAGE_FRAME_INSERT_MODE_TOP or SCROLLING_MESSAGE_FRAME_INSERT_MODE_BOTTOM)
-			end
+            -- Insert Direction
+            if settings.insertText then
+                f:SetInsertMode(settings.insertText == 'top' and SCROLLING_MESSAGE_FRAME_INSERT_MODE_TOP or SCROLLING_MESSAGE_FRAME_INSERT_MODE_BOTTOM)
+            end
 
-			-- Font Template
-			local outline = ssub(settings.fontOutline, 2)
-			
-			if outline == "NONE" then
-				f:SetFont(LSM:Fetch("font", settings.font), settings.fontSize, "")
-			else
-				f:SetFont(LSM:Fetch("font", settings.font), settings.fontSize, outline)
-			end
+            -- Font Template
+            local outline = ssub(settings.fontOutline, 2)
+            
+            if outline == "NONE" then
+                f:SetFont(LSM:Fetch("font", settings.font), settings.fontSize, "")
+            else
+                f:SetFont(LSM:Fetch("font", settings.font), settings.fontSize, outline)
+            end
 
-			if settings.fontJustify then
-				f:SetJustifyH(settings.fontJustify)
-			end
+            if settings.fontJustify then
+                f:SetJustifyH(settings.fontJustify)
+            end
 
-			-- Special Cases
-			if framename == "class" then
-				f:SetMaxLines(1)
-				f:SetFading(false)
-			else
-				-- scrolling
-				if settings.enableScrollable then
-					f:SetMaxLines(settings.scrollableLines)
-					if not settings.scrollableInCombat then
-						if InCombatLockdown() then
-							x:DisableFrameScrolling( framename )
-						else
-							x:EnableFrameScrolling( framename )
-						end
-					else
-						x:EnableFrameScrolling( framename )
-					end
-				else
-					f:SetMaxLines(math.max(1, mfloor(settings.Height / settings.fontSize) - 1)) --- shhhhhhhhhhhhhhhhhhhh
-					x:DisableFrameScrolling( framename )
-				end
-			end
+            -- Special Cases
+            if framename == "class" then
+                f:SetMaxLines(1)
+                f:SetFading(false)
+            else
+                -- scrolling
+                if settings.enableScrollable then
+                    f:SetMaxLines(settings.scrollableLines)
+                    if not settings.scrollableInCombat then
+                        if InCombatLockdown() then
+                            x:DisableFrameScrolling( framename )
+                        else
+                            x:EnableFrameScrolling( framename )
+                        end
+                    else
+                        x:EnableFrameScrolling( framename )
+                    end
+                else
+                    f:SetMaxLines(math.max(1, mfloor(settings.Height / settings.fontSize) - 1)) --- shhhhhhhhhhhhhhhhhhhh
+                    x:DisableFrameScrolling( framename )
+                end
+            end
 
-			-- fading
-			if settings.enableCustomFade then
-				f:SetFading(settings.enableFade)
-				f:SetFadeDuration(settings.fadeTime)
-				f:SetTimeVisible(settings.visibilityTime)
-			else
-				f:SetFading(true)
-				f:SetTimeVisible(3)
-			end
+            -- fading
+            if settings.enableCustomFade then
+                f:SetFading(settings.enableFade)
+                f:SetFadeDuration(settings.fadeTime)
+                f:SetTimeVisible(settings.visibilityTime)
+            else
+                f:SetFading(true)
+                f:SetTimeVisible(3)
+            end
 
-			if settings.enableFontShadow then
-				f:SetShadowColor(unpack(settings.fontShadowColor))
-				f:SetShadowOffset(settings.fontShadowOffsetX, settings.fontShadowOffsetY)
-			else
-				f:SetShadowColor(0, 0, 0, 0)
-			end
+            if settings.enableFontShadow then
+                f:SetShadowColor(unpack(settings.fontShadowColor))
+                f:SetShadowOffset(settings.fontShadowOffsetX, settings.fontShadowOffsetY)
+            else
+                f:SetShadowColor(0, 0, 0, 0)
+            end
 
-			-- Send a Test message
-			if specificFrame then
-				f:SetScript("OnUpdate", Frame_SendTestMessage_OnUpdate)
-			end
+            -- Send a Test message
+            if specificFrame then
+                f:SetScript("OnUpdate", Frame_SendTestMessage_OnUpdate)
+            end
 
-			if settings.enabledFrame then
-				f:Show()
-			else
-				f:Hide()
-			end
-		end
-	end
+            if settings.enabledFrame then
+                f:Show()
+            else
+                f:Hide()
+            end
+        end
+    end
 end
 
 function x:EnableFrameScrolling( framename )
@@ -300,181 +300,181 @@ end
 
 -- =====================================================
 -- AddOn:Clear(
---		specificFrame,	[string] - (Optional) the framename
---	)
---		If you specify a specificFrame then only that
---	frame will be cleared of its text, otherwise all
---	the frames will be cleared.
+--        specificFrame,    [string] - (Optional) the framename
+--    )
+--        If you specify a specificFrame then only that
+--    frame will be cleared of its text, otherwise all
+--    the frames will be cleared.
 -- =====================================================
 function x:Clear(specificFrame)
-	if not specificFrame then
-		for framename, settings in pairs(x.db.profile.frames) do
-			local frame = x:GetFrame(framename)
-			if frame then -- attempt to fix login 'attempt to index nil value frame' error
-				frame:Clear()
-			end
-		end
-	else
-		local frame = x:GetFrame(specificFrame)
-		frame:Clear()
-	end
+    if not specificFrame then
+        for framename, settings in pairs(x.db.profile.frames) do
+            local frame = x:GetFrame(framename)
+            if frame then -- attempt to fix login 'attempt to index nil value frame' error
+                frame:Clear()
+            end
+        end
+    else
+        local frame = x:GetFrame(specificFrame)
+        frame:Clear()
+    end
 end
 
 -- =====================================================
 -- AddOn:Abbreviate(
---		amount,				 [int] - the amount to abbreviate
---		frameName*,	[string] - the name of the frame
---			whose settings we need to check.
---	)
+--        amount,                 [int] - the amount to abbreviate
+--        frameName*,    [string] - the name of the frame
+--            whose settings we need to check.
+--    )
 --
---		* = Optional
+--        * = Optional
 --
---		Abbreviates the specified amount.	Will also
---	check the current settings profile if a name
---	frame is specified.
+--        Abbreviates the specified amount.    Will also
+--    check the current settings profile if a name
+--    frame is specified.
 -- =====================================================
 function x:Abbreviate(amount, frameName)
-	local isNegative = amount < 0
-	if isNegative then amount = -amount end
-	local message = tostring(amount)
+    local isNegative = amount < 0
+    if isNegative then amount = -amount end
+    local message = tostring(amount)
 
-	if frameName and self.db.profile.frames[frameName] and self.db.profile.frames[frameName].megaDamage then
-		if self.db.profile.spells.formatAbbreviate then
-			if GetLocale() == "koKR" then
-				if (amount >= 100000000) then
-					if self.db.profile.megaDamage.decimalPoint then
-						message = tostring(mfloor((amount + 5000000) / 10000000) / 10) .. self.db.profile.megaDamage.billionSymbol
-					else
-						message = tostring(mfloor((amount + 50000000) / 100000000)) .. self.db.profile.megaDamage.billionSymbol
-					end
-				elseif (amount >= 10000) then
-					if self.db.profile.megaDamage.decimalPoint then
-						message = tostring(mfloor((amount + 500) / 1000) / 10) .. self.db.profile.megaDamage.millionSymbol
-					else
-						message = tostring(mfloor((amount + 5000) / 10000)) .. self.db.profile.megaDamage.millionSymbol
-					end
-				elseif (amount >= 1000) then
-					if self.db.profile.megaDamage.decimalPoint then
-						message = tostring(mfloor((amount + 50) / 100) / 10) .. self.db.profile.megaDamage.thousandSymbol
-					else
-						message = tostring(mfloor((amount + 500) / 1000)) .. self.db.profile.megaDamage.thousandSymbol
-					end
-				end
-			else
-				if (amount >= 1000000000) then
-					if self.db.profile.megaDamage.decimalPoint then
-						message = tostring(mfloor((amount + 50000000) / 100000000) / 10) .. self.db.profile.megaDamage.billionSymbol
-					else
-						message = tostring(mfloor((amount + 500000000) / 1000000000)) .. self.db.profile.megaDamage.billionSymbol
-					end
-				elseif (amount >= 1000000) then
-					if self.db.profile.megaDamage.decimalPoint then
-						message = tostring(mfloor((amount + 50000) / 100000) / 10) .. self.db.profile.megaDamage.millionSymbol
-					else
-						message = tostring(mfloor((amount + 500000) / 1000000)) .. self.db.profile.megaDamage.millionSymbol
-					end
-				elseif (amount >= 1000) then
-					if self.db.profile.megaDamage.decimalPoint then
-						message = tostring(mfloor((amount + 50) / 100) / 10) .. self.db.profile.megaDamage.thousandSymbol
-					else
-						message = tostring(mfloor((amount + 500) / 1000)) .. self.db.profile.megaDamage.thousandSymbol
-					end
-				end
-			end
+    if frameName and self.db.profile.frames[frameName] and self.db.profile.frames[frameName].megaDamage then
+        if self.db.profile.spells.formatAbbreviate then
+            if GetLocale() == "koKR" then
+                if (amount >= 100000000) then
+                    if self.db.profile.megaDamage.decimalPoint then
+                        message = tostring(mfloor((amount + 5000000) / 10000000) / 10) .. self.db.profile.megaDamage.billionSymbol
+                    else
+                        message = tostring(mfloor((amount + 50000000) / 100000000)) .. self.db.profile.megaDamage.billionSymbol
+                    end
+                elseif (amount >= 10000) then
+                    if self.db.profile.megaDamage.decimalPoint then
+                        message = tostring(mfloor((amount + 500) / 1000) / 10) .. self.db.profile.megaDamage.millionSymbol
+                    else
+                        message = tostring(mfloor((amount + 5000) / 10000)) .. self.db.profile.megaDamage.millionSymbol
+                    end
+                elseif (amount >= 1000) then
+                    if self.db.profile.megaDamage.decimalPoint then
+                        message = tostring(mfloor((amount + 50) / 100) / 10) .. self.db.profile.megaDamage.thousandSymbol
+                    else
+                        message = tostring(mfloor((amount + 500) / 1000)) .. self.db.profile.megaDamage.thousandSymbol
+                    end
+                end
+            else
+                if (amount >= 1000000000) then
+                    if self.db.profile.megaDamage.decimalPoint then
+                        message = tostring(mfloor((amount + 50000000) / 100000000) / 10) .. self.db.profile.megaDamage.billionSymbol
+                    else
+                        message = tostring(mfloor((amount + 500000000) / 1000000000)) .. self.db.profile.megaDamage.billionSymbol
+                    end
+                elseif (amount >= 1000000) then
+                    if self.db.profile.megaDamage.decimalPoint then
+                        message = tostring(mfloor((amount + 50000) / 100000) / 10) .. self.db.profile.megaDamage.millionSymbol
+                    else
+                        message = tostring(mfloor((amount + 500000) / 1000000)) .. self.db.profile.megaDamage.millionSymbol
+                    end
+                elseif (amount >= 1000) then
+                    if self.db.profile.megaDamage.decimalPoint then
+                        message = tostring(mfloor((amount + 50) / 100) / 10) .. self.db.profile.megaDamage.thousandSymbol
+                    else
+                        message = tostring(mfloor((amount + 500) / 1000)) .. self.db.profile.megaDamage.thousandSymbol
+                    end
+                end
+            end
 
-			if isNegative then message = '-' .. message end
-		else
-			local k
-			while true do
-				message, k = sgsub(message, '^(-?%d+)(%d%d%d)', '%1,%2')
-				if (k==0) then break end
-			end
-		end
-	end
-	return message
+            if isNegative then message = '-' .. message end
+        else
+            local k
+            while true do
+                message, k = sgsub(message, '^(-?%d+)(%d%d%d)', '%1,%2')
+                if (k==0) then break end
+            end
+        end
+    end
+    return message
 end
 
 -- =====================================================
 -- AddOn:AddMessage(
---		framename,	[string] - the framename
---		message,	[string] - the pre-formatted message to be sent
---		colorname,	[string or table] - the name of the color OR a
---										table containing the color
---										e.g. colorname={1,2,3} --r=1,b=2,g=3
---	)
---		Sends a message to the framename specified.
+--        framename,    [string] - the framename
+--        message,    [string] - the pre-formatted message to be sent
+--        colorname,    [string or table] - the name of the color OR a
+--                                        table containing the color
+--                                        e.g. colorname={1,2,3} --r=1,b=2,g=3
+--    )
+--        Sends a message to the framename specified.
 -- =====================================================
 function x:AddMessage(framename, message, colorname)
-	local frame = x:GetFrame(framename, true)
-	local frameOptions = x.db.profile.frames[framename]
+    local frame = x:GetFrame(framename, true)
+    local frameOptions = x.db.profile.frames[framename]
 
-	-- Make sure we have a valid frame
-	if not frameOptions then print("xct+ frame name not found:", framename) return end
+    -- Make sure we have a valid frame
+    if not frameOptions then print("xct+ frame name not found:", framename) return end
 
-	local secondFrameName = frameIndex[frameOptions.secondaryFrame]
-	local secondFrame = x.frames[secondFrameName]
-	local secondFrameOptions = x.db.profile.frames[secondFrameName]
+    local secondFrameName = frameIndex[frameOptions.secondaryFrame]
+    local secondFrame = x.frames[secondFrameName]
+    local secondFrameOptions = x.db.profile.frames[secondFrameName]
 
-	if frame then
-		-- Load the color
-		local r, g, b = 1, 1, 1
-		if type(colorname) == "table" then
-			r, g, b = unpack(colorname)
-		else
-			local color = x.LookupColorByName(colorname)
-			if color then
-				r, g, b = unpack(color)
-			else
-				print("FRAME:", framename,"  xct+ says there is no color named:", colorname)
-				error("missing color")
-			end
-		end
+    if frame then
+        -- Load the color
+        local r, g, b = 1, 1, 1
+        if type(colorname) == "table" then
+            r, g, b = unpack(colorname)
+        else
+            local color = x.LookupColorByName(colorname)
+            if color then
+                r, g, b = unpack(color)
+            else
+                print("FRAME:", framename,"  xct+ says there is no color named:", colorname)
+                error("missing color")
+            end
+        end
 
-		-- make sure the frame is enabled
-		if frameOptions.enabledFrame then
-			-- check for forced color
-			if frameOptions.customColor then
-				r, g, b = unpack(frameOptions.fontColor or {1, 1, 1})
-			end
-			frame:AddMessage(message, r, g, b)
-		elseif secondFrame and secondFrameOptions.enabledFrame then
-			if secondFrameOptions.customColor then			-- check for forced color
-				r, g, b = unpack(secondFrameOptions.fontColor or {1, 1, 1})
-			end
-			secondFrame:AddMessage(message, r, g, b)
-		end
-	end
+        -- make sure the frame is enabled
+        if frameOptions.enabledFrame then
+            -- check for forced color
+            if frameOptions.customColor then
+                r, g, b = unpack(frameOptions.fontColor or {1, 1, 1})
+            end
+            frame:AddMessage(message, r, g, b)
+        elseif secondFrame and secondFrameOptions.enabledFrame then
+            if secondFrameOptions.customColor then            -- check for forced color
+                r, g, b = unpack(secondFrameOptions.fontColor or {1, 1, 1})
+            end
+            secondFrame:AddMessage(message, r, g, b)
+        end
+    end
 end
 
 -- WoW - Battle for Azeroth doesn't support fading textures with SetAlpha?
 -- We have to do it on a font string level
 local ScrollingMessageFrame_OverrideAlpha_Worker = CreateFrame("FRAME")
 ScrollingMessageFrame_OverrideAlpha_Worker:SetScript("OnUpdate", function ()
-	local now, alpha, scale = GetTime()
-	for name, frame in pairs(x.frames) do
-		alpha = frame.settings.alpha / 100
+    local now, alpha, scale = GetTime()
+    for name, frame in pairs(x.frames) do
+        alpha = frame.settings.alpha / 100
 
-		-- Only run on frames that have a custom alpha
-		if alpha ~= 1 then
-			-- Loop through each fontstring
-			for lineIndex, visibleLine in ipairs(frame.visibleLines) do
-				if visibleLine.messageInfo then -- Check for valid font strings (not released)
-					-- Keep the default fading, we will use their value to scale the custom alpha
-					scale = frame:CalculateLineAlphaValueFromTimestamp(now, math.max(visibleLine.messageInfo.timestamp, frame.overrideFadeTimestamp))
+        -- Only run on frames that have a custom alpha
+        if alpha ~= 1 then
+            -- Loop through each fontstring
+            for lineIndex, visibleLine in ipairs(frame.visibleLines) do
+                if visibleLine.messageInfo then -- Check for valid font strings (not released)
+                    -- Keep the default fading, we will use their value to scale the custom alpha
+                    scale = frame:CalculateLineAlphaValueFromTimestamp(now, math.max(visibleLine.messageInfo.timestamp, frame.overrideFadeTimestamp))
 
-					-- If we are fading the message away and fading is enabled
-					if scale ~= 1 and frame:CanEffectivelyFade() then
-						visibleLine:SetAlpha(alpha * scale)	-- Fade the font string, scaled for the custom amount
+                    -- If we are fading the message away and fading is enabled
+                    if scale ~= 1 and frame:CanEffectivelyFade() then
+                        visibleLine:SetAlpha(alpha * scale)    -- Fade the font string, scaled for the custom amount
 
-					-- Only change the font string's alpha if it didn't already change
-					elseif visibleLine:GetAlpha() ~= alpha then
-						visibleLine:SetAlpha(alpha)
-					end
-				end
-			end
-		end
+                    -- Only change the font string's alpha if it didn't already change
+                    elseif visibleLine:GetAlpha() ~= alpha then
+                        visibleLine:SetAlpha(alpha)
+                    end
+                end
+            end
+        end
 
-	end
+    end
 end)
 
 
@@ -483,72 +483,72 @@ local spam_format = "%s%s x%s"
 
 -- =====================================================
 -- AddOn:AddSpamMessage(
---		framename,		[string]              - the framename
---		mergeID,		[number or string]      - idenitity items to merge, if number
---												then it HAS TO BE the valid spell ID
---		message,		[number or string]      - the pre-formatted message to be sent,
---												if its not a number, then only the
---												first 'message' value that is sent
---												this mergeID will be used.
---		colorname,		[string or table]     - the name of the color OR a table
---												containing the color (e.g.
---												colorname={1,2,3} -- r=1, b=2, g=3)
---	)
---		Sends a message to the framename specified.
+--        framename,        [string]              - the framename
+--        mergeID,        [number or string]      - idenitity items to merge, if number
+--                                                then it HAS TO BE the valid spell ID
+--        message,        [number or string]      - the pre-formatted message to be sent,
+--                                                if its not a number, then only the
+--                                                first 'message' value that is sent
+--                                                this mergeID will be used.
+--        colorname,        [string or table]     - the name of the color OR a table
+--                                                containing the color (e.g.
+--                                                colorname={1,2,3} -- r=1, b=2, g=3)
+--    )
+--        Sends a message to the framename specified.
 -- =====================================================
 function x:AddSpamMessage(framename, mergeID, message, colorname, interval, prep, ...)
 
-	-- Check for a Secondary Spell ID
-	mergeID = addon.merge2h[mergeID] or mergeID
+    -- Check for a Secondary Spell ID
+    mergeID = addon.merge2h[mergeID] or mergeID
 
-	-- how often to update
-	interval = interval or (db and db.interval) or 0.5
+    -- how often to update
+    interval = interval or (db and db.interval) or 0.5
 
-	local heap, stack = spamHeap[framename], spamStack[framename]
-	if heap[mergeID] then
-		heap[mergeID].color = colorname
+    local heap, stack = spamHeap[framename], spamStack[framename]
+    if heap[mergeID] then
+        heap[mergeID].color = colorname
 
-		if tonumber(message) then
-			heap[mergeID].mergedAmount = heap[mergeID].mergedAmount + tonumber(message)
-			heap[mergeID].mergedCount  = heap[mergeID].mergedCount + 1
-		end
+        if tonumber(message) then
+            heap[mergeID].mergedAmount = heap[mergeID].mergedAmount + tonumber(message)
+            heap[mergeID].mergedCount  = heap[mergeID].mergedCount + 1
+        end
 
-		if heap[mergeID].displayTime <= now then
-			heap[mergeID].displayTime = now + interval
-		end
-	else
-		local db = addon.defaults.profile.spells.merge[mergeID]
+        if heap[mergeID].displayTime <= now then
+            heap[mergeID].displayTime = now + interval
+        end
+    else
+        local db = addon.defaults.profile.spells.merge[mergeID]
 
-		heap[mergeID] = {
-			-- after this time we display it on the frame
-			displayTime = now + interval,
+        heap[mergeID] = {
+            -- after this time we display it on the frame
+            displayTime = now + interval,
 
-			-- how often to update
-			update = interval,
+            -- how often to update
+            update = interval,
 
-			prep = prep or (db and db.prep) or interval or 0.5,
+            prep = prep or (db and db.prep) or interval or 0.5,
 
-			-- merged entries
-			mergedAmount = tonumber(message) or 0,
-			mergedCount = 1,
+            -- merged entries
+            mergedAmount = tonumber(message) or 0,
+            mergedCount = 1,
 
-			-- color
-			color = colorname,
-		}
+            -- color
+            color = colorname,
+        }
 
-		if select("#", ...) % 2 ~= 0 then
-			error("an even amount of extra args are required to add an entry to merge")
-		end
-		--print("extra args pairs:", select("#", ...)/2)
-		for i=1,select("#", ...),2 do
-			if heap[mergeID][select(i, ...)] then
-				error("reserved keyword in entry added to merge: '" .. tostring(select(i, ...)) .. "'")
-			end
-			--print(" -->", select(i, ...), "=", select(i+1, ...))
-			heap[mergeID][select(i, ...)] = select(i+1, ...)
-		end
-		table_insert(stack, mergeID)
-	end
+        if select("#", ...) % 2 ~= 0 then
+            error("an even amount of extra args are required to add an entry to merge")
+        end
+        --print("extra args pairs:", select("#", ...)/2)
+        for i=1,select("#", ...),2 do
+            if heap[mergeID][select(i, ...)] then
+                error("reserved keyword in entry added to merge: '" .. tostring(select(i, ...)) .. "'")
+            end
+            --print(" -->", select(i, ...), "=", select(i+1, ...))
+            heap[mergeID][select(i, ...)] = select(i+1, ...)
+        end
+        table_insert(stack, mergeID)
+    end
 end
 
 --[================================================================[
@@ -566,813 +566,813 @@ end
       | |                                          __/ |
       |_|                                         |___/
 
-	This is the new spam merger.	Here is how it works:
+    This is the new spam merger.    Here is how it works:
 
-	-- On Each Update
-		+ Go to the current frame (one frame at a time)
+    -- On Each Update
+        + Go to the current frame (one frame at a time)
 
-			- Go to the current spell entry for this frame
-				+ if spell entry says its time to update, then update
-				+ else do nothing
+            - Go to the current spell entry for this frame
+                + if spell entry says its time to update, then update
+                + else do nothing
 
-			- Get the next spell entry ready for the next time it hits this frame
+            - Get the next spell entry ready for the next time it hits this frame
 
-		+ Get the next frame ready for the next update
+        + Get the next frame ready for the next update
 
-		+ Wait for next Update
+        + Wait for next Update
 
-			As you can see, I only update one frame per OnUpdate AND only
-		one merge entry gets updated for every frame.	Which means, I will
-		do a maximum of one thing per OnUpdate (and a minimum of nothing).
-		I am hoping that the spell merger will be mostly invisible.
+            As you can see, I only update one frame per OnUpdate AND only
+        one merge entry gets updated for every frame.    Which means, I will
+        do a maximum of one thing per OnUpdate (and a minimum of nothing).
+        I am hoping that the spell merger will be mostly invisible.
 
 
-	 -- TODO:	The only thing that I need to figure out is: is the spell
-		merger updating fast enough, or will it feel slugish when there are
-		a lot of items to merge.
+     -- TODO:    The only thing that I need to figure out is: is the spell
+        merger updating fast enough, or will it feel slugish when there are
+        a lot of items to merge.
 
-			My best guess is that it does not matter :)
+            My best guess is that it does not matter :)
 
   ]================================================================]
 
 do
-	for _, frameName in pairs(frameIndex) do
-		spamHeap[frameName] = {}
-		spamStack[frameName] = {}
-	end
+    for _, frameName in pairs(frameIndex) do
+        spamHeap[frameName] = {}
+        spamStack[frameName] = {}
+    end
 
-	local index = 1 -- keeps track of the frame
-	local frames = {} -- keeps track of the current stack index for that frame
+    local index = 1 -- keeps track of the frame
+    local frames = {} -- keeps track of the current stack index for that frame
 
-	local fakeArgs = {}
+    local fakeArgs = {}
 
-	function x.OnSpamUpdate(self, elapsed)
-		if not x.db then return end
+    function x.OnSpamUpdate(self, elapsed)
+        if not x.db then return end
 
-		-- Update 'now'
-		now = now + elapsed
+        -- Update 'now'
+        now = now + elapsed
 
-		-- Check to see if we are out of bounds
-		if index > #frameIndex then index = 1 end
-		local frameName = frameIndex[index]
+        -- Check to see if we are out of bounds
+        if index > #frameIndex then index = 1 end
+        local frameName = frameIndex[index]
 
-		-- frame doesn't exist in 'frames' (keeps track of the current stack index for that frame)
-		if not frames[frameName] then
-			frames[frameName] = 1
-		end
+        -- frame doesn't exist in 'frames' (keeps track of the current stack index for that frame)
+        if not frames[frameName] then
+            frames[frameName] = 1
+        end
 
-		local heap, stack, settings, idIndex =
-			spamHeap[frameName],            -- the heap contains merge entries
-			spamStack[frameName],           -- the stack contains lookup values
-			x.db.profile.frames[frameName], -- this frame's settings
-			frames[frameName]               -- this frame's last entry index
+        local heap, stack, settings, idIndex =
+            spamHeap[frameName],            -- the heap contains merge entries
+            spamStack[frameName],           -- the stack contains lookup values
+            x.db.profile.frames[frameName], -- this frame's settings
+            frames[frameName]               -- this frame's last entry index
 
-		-- If the frame is not enabled, then dont even worry about it
-		if not settings.enabledFrame and settings.secondaryFrame == 0 then
-			index = index + 1	-- heh, still need to iterate to the next frame :P
-			return
-		end
+        -- If the frame is not enabled, then dont even worry about it
+        if not settings.enabledFrame and settings.secondaryFrame == 0 then
+            index = index + 1    -- heh, still need to iterate to the next frame :P
+            return
+        end
 
-		-- Check to see if we are out of bounds
-		if idIndex > #stack then
-			idIndex = 1
-		end
+        -- Check to see if we are out of bounds
+        if idIndex > #stack then
+            idIndex = 1
+        end
 
-		-- This item contains a lot of information about what we need to merge
-		local item = heap[stack[idIndex]]
+        -- This item contains a lot of information about what we need to merge
+        local item = heap[stack[idIndex]]
 
-		--if item then print(item.displayTime, " < ", now, "?") end
-		if item and item.displayTime <= now and item.mergedCount > 0 then
-			item.displayTime = now
+        --if item then print(item.displayTime, " < ", now, "?") end
+        if item and item.displayTime <= now and item.mergedCount > 0 then
+            item.displayTime = now
 
-			-- total as a string
-			local message
+            -- total as a string
+            local message
 
-			-- Abbreviate the merged total
-			if tonumber(item.mergedAmount) then
-				message = x:Abbreviate(tonumber(item.mergedAmount), frameName)
-			else
-				message = tostring(item.mergedAmount)
-			end
+            -- Abbreviate the merged total
+            if tonumber(item.mergedAmount) then
+                message = x:Abbreviate(tonumber(item.mergedAmount), frameName)
+            else
+                message = tostring(item.mergedAmount)
+            end
 
-			--local format_mergeCount = "%s |cffFFFFFFx%s|r"
-			local strColor = "ffffff"
+            --local format_mergeCount = "%s |cffFFFFFFx%s|r"
+            local strColor = "ffffff"
 
-			-- Add critical Prefix and Postfix
-			if frameName == "outgoing" or frameName == "critical" then
-				if frameName == "critical" then
-					message = format("%s%s%s", settings.critPrefix, message, settings.critPostfix)
-				end
-				if settings.names[item.destinationController].nameType == 2 then
-					if item.auto then
-						fakeArgs.spellName = item.auto
-						fakeArgs.spellSchool = 1 -- physical
-					else
-						fakeArgs.spellName = item.spellName
-						fakeArgs.spellSchool = item.spellSchool
-					end
-					--fakeArgs.fake_sourceController = item.sourceController
-					fakeArgs.fake_destinationController = item.destinationController
-					if settings.fontJustify == "RIGHT" then
-						message = x.formatName(fakeArgs, settings.names) .. " " .. message
-					else
-						message = message .. x.formatName(fakeArgs, settings.names)
-					end
-				end
+            -- Add critical Prefix and Postfix
+            if frameName == "outgoing" or frameName == "critical" then
+                if frameName == "critical" then
+                    message = format("%s%s%s", settings.critPrefix, message, settings.critPostfix)
+                end
+                if settings.names[item.destinationController].nameType == 2 then
+                    if item.auto then
+                        fakeArgs.spellName = item.auto
+                        fakeArgs.spellSchool = 1 -- physical
+                    else
+                        fakeArgs.spellName = item.spellName
+                        fakeArgs.spellSchool = item.spellSchool
+                    end
+                    --fakeArgs.fake_sourceController = item.sourceController
+                    fakeArgs.fake_destinationController = item.destinationController
+                    if settings.fontJustify == "RIGHT" then
+                        message = x.formatName(fakeArgs, settings.names) .. " " .. message
+                    else
+                        message = message .. x.formatName(fakeArgs, settings.names)
+                    end
+                end
 
-			-- Show healer name (colored)
-			elseif frameName == "healing" then
-				--format_mergeCount = "%s |cffFFFF00x%s|r"
-				local strColor = "ffff00"
+            -- Show healer name (colored)
+            elseif frameName == "healing" then
+                --format_mergeCount = "%s |cffFFFF00x%s|r"
+                local strColor = "ffff00"
 
-				if settings.names[item.sourceController].nameType == 1 then
-					fakeArgs.sourceName = stack[idIndex]
-					fakeArgs.sourceGUID = item.sourceGUID
-					fakeArgs.fake_sourceController = item.sourceController
-					if settings.fontJustify == "RIGHT" then
-						message = x.formatName(fakeArgs, settings.names, true) .. " +" .. message
-					else
-						message = "+" .. message .. x.formatName(fakeArgs, settings.names, true)
-					end
-				else
-					message = sformat("+%s", message)
-				end
-			end
+                if settings.names[item.sourceController].nameType == 1 then
+                    fakeArgs.sourceName = stack[idIndex]
+                    fakeArgs.sourceGUID = item.sourceGUID
+                    fakeArgs.fake_sourceController = item.sourceController
+                    if settings.fontJustify == "RIGHT" then
+                        message = x.formatName(fakeArgs, settings.names, true) .. " +" .. message
+                    else
+                        message = "+" .. message .. x.formatName(fakeArgs, settings.names, true)
+                    end
+                else
+                    message = sformat("+%s", message)
+                end
+            end
 
-			-- Add Icons
-			if frameName == "outgoing" or frameName == "critical" then
-				message = x:GetSpellTextureFormatted( stack[idIndex],
-				                                      message,
-				                                      settings.iconsEnabled and settings.iconsSize or -1,
-				                                      settings.spacerIconsEnabled,
-				                                      settings.fontJustify,
-				                                      strColor,
-				                                      true, -- Merge Override = true
-				                                      item.mergedCount )
-			elseif frameName == "healing" or frameName == "damage" then
-				if item.mergedCount > 1 then
-					message = sformat(" |T"..x.BLANK_ICON..":%d:%d:0:0:64:64:5:59:5:59|t %s |cff%sx%s|r", settings.iconsSize, settings.iconsSize, message, strColor, item.mergedCount)
-				else
-					message = sformat(" |T"..x.BLANK_ICON..":%d:%d:0:0:64:64:5:59:5:59|t %s", settings.iconsSize, settings.iconsSize, message)
-				end
-			end
+            -- Add Icons
+            if frameName == "outgoing" or frameName == "critical" then
+                message = x:GetSpellTextureFormatted( stack[idIndex],
+                                                      message,
+                                                      settings.iconsEnabled and settings.iconsSize or -1,
+                                                      settings.spacerIconsEnabled,
+                                                      settings.fontJustify,
+                                                      strColor,
+                                                      true, -- Merge Override = true
+                                                      item.mergedCount )
+            elseif frameName == "healing" or frameName == "damage" then
+                if item.mergedCount > 1 then
+                    message = sformat(" |T"..x.BLANK_ICON..":%d:%d:0:0:64:64:5:59:5:59|t %s |cff%sx%s|r", settings.iconsSize, settings.iconsSize, message, strColor, item.mergedCount)
+                else
+                    message = sformat(" |T"..x.BLANK_ICON..":%d:%d:0:0:64:64:5:59:5:59|t %s", settings.iconsSize, settings.iconsSize, message)
+                end
+            end
 
-			x:AddMessage(frameIndex[index], message, item.color)
+            x:AddMessage(frameIndex[index], message, item.color)
 
-			-- Clear all the old amounts, we dont need them anymore
-			item.mergedAmount = 0
-			item.mergedCount  = 0
-		end
+            -- Clear all the old amounts, we dont need them anymore
+            item.mergedAmount = 0
+            item.mergedCount  = 0
+        end
 
-		frames[frameIndex[index]] = idIndex + 1
-		index = index + 1
-	end
+        frames[frameIndex[index]] = idIndex + 1
+        index = index + 1
+    end
 
-	x.merge = CreateFrame("FRAME")
-	x.merge:SetScript("OnUpdate", x.OnSpamUpdate)
+    x.merge = CreateFrame("FRAME")
+    x.merge:SetScript("OnUpdate", x.OnSpamUpdate)
 end
 
 local function Frame_Sizing_OnUpdate(self, e)
-	local settings = self.parent.settings
-	local width, height = mfloor(self.parent:GetWidth()+.5), mfloor(self.parent:GetHeight()+.5)
-	self.parent.width:SetText(width)
-	self.parent.height:SetText(height)
+    local settings = self.parent.settings
+    local width, height = mfloor(self.parent:GetWidth()+.5), mfloor(self.parent:GetHeight()+.5)
+    self.parent.width:SetText(width)
+    self.parent.height:SetText(height)
 
-	self.parent:SetMaxLines(mfloor(height / settings.fontSize) - 1)
+    self.parent:SetMaxLines(mfloor(height / settings.fontSize) - 1)
 end
 
 local function Frame_Moving_OnUpdate(self, e)
-	-- Calculate get the center of the screen from the left/top
-	local posX = mfloor(mfloor(self.parent:GetLeft()-GetScreenWidth()/2+.5))
-	local posY = mfloor(mfloor(self.parent:GetTop()-GetScreenHeight()/2+.5))
+    -- Calculate get the center of the screen from the left/top
+    local posX = mfloor(mfloor(self.parent:GetLeft()-GetScreenWidth()/2+.5))
+    local posY = mfloor(mfloor(self.parent:GetTop()-GetScreenHeight()/2+.5))
 
-	-- Set the position of the frame
-	self.parent.position:SetText(sformat("%d, %d", posX, posY))
+    -- Set the position of the frame
+    self.parent.position:SetText(sformat("%d, %d", posX, posY))
 end
 
 local function Frame_Sizing_OnMouseDown(self, button)
-	if button == "LeftButton" then
-		self.parent:StartSizing()
-		self:SetScript("OnUpdate", Frame_Sizing_OnUpdate)
-		self.isMoving = true
-	end
+    if button == "LeftButton" then
+        self.parent:StartSizing()
+        self:SetScript("OnUpdate", Frame_Sizing_OnUpdate)
+        self.isMoving = true
+    end
 end
 
 local function Frame_Sizing_OnMouseUp(self, button)
-	if button == "LeftButton" and self.isMoving then
-		self.parent:StopMovingOrSizing()
-		self:SetScript("OnUpdate", nil)
-		self.isMoving = false
-	end
+    if button == "LeftButton" and self.isMoving then
+        self.parent:StopMovingOrSizing()
+        self:SetScript("OnUpdate", nil)
+        self.isMoving = false
+    end
 end
 
 local function Frame_Moving_OnMouseDown(self, button)
-	if button == "LeftButton" then
-		self.parent:StartMoving()
-		self:SetScript("OnUpdate", Frame_Moving_OnUpdate)
-		self.isMoving = true
-	end
+    if button == "LeftButton" then
+        self.parent:StartMoving()
+        self:SetScript("OnUpdate", Frame_Moving_OnUpdate)
+        self.isMoving = true
+    end
 end
 
 local function Frame_Moving_OnMouseUp(self, button)
-	if button == "LeftButton" and self.isMoving then
-		self.parent:StopMovingOrSizing()
-		self:SetScript("OnUpdate", nil)
-		self.isMoving = false
-	end
+    if button == "LeftButton" and self.isMoving then
+        self.parent:StopMovingOrSizing()
+        self:SetScript("OnUpdate", nil)
+        self.isMoving = false
+    end
 end
 
 local function Frame_MouseEnter(self)
-	if x.db.profile.frameSettings.showPositions then
-		if self.width then
-			self.width:Show()
-			self.height:Show()
-			self.position:Show()
-		else
-			self.parent.width:Show()
-			self.parent.height:Show()
-			self.parent.position:Show()
-		end
-	end
+    if x.db.profile.frameSettings.showPositions then
+        if self.width then
+            self.width:Show()
+            self.height:Show()
+            self.position:Show()
+        else
+            self.parent.width:Show()
+            self.parent.height:Show()
+            self.parent.position:Show()
+        end
+    end
 end
 
 local function Frame_MouseLeave(self)
-	if self.width then
-		self.width:Hide()
-		self.height:Hide()
-		self.position:Hide()
-	else
-		self.parent.width:Hide()
-		self.parent.height:Hide()
-		self.parent.position:Hide()
-	end
+    if self.width then
+        self.width:Hide()
+        self.height:Hide()
+        self.position:Hide()
+    else
+        self.parent.width:Hide()
+        self.parent.height:Hide()
+        self.parent.position:Hide()
+    end
 end
 
 -- Starts the "config mode" so that you can move the frames
 function x.StartConfigMode()
-	x.configuring = true
+    x.configuring = true
 
-	for framename, settings in pairs(x.db.profile.frames) do
-		if settings.enabledFrame then
-			local f = x:GetFrame(framename)
+    for framename, settings in pairs(x.db.profile.frames) do
+        if settings.enabledFrame then
+            local f = x:GetFrame(framename)
 
-			f:SetBackdrop( {
-					bgFile	 	= "Interface/Tooltips/UI-Tooltip-Background",
-					edgeFile 	= "Interface/Tooltips/UI-Tooltip-Border",
-					tile		= false,
-					tileSize 	= 0,
-					edgeSize 	= 2,
-					insets 		= { left = 0, right = 0, top = 0, bottom = 0 }
-				} )
+            f:SetBackdrop( {
+                    bgFile         = "Interface/Tooltips/UI-Tooltip-Background",
+                    edgeFile     = "Interface/Tooltips/UI-Tooltip-Border",
+                    tile        = false,
+                    tileSize     = 0,
+                    edgeSize     = 2,
+                    insets         = { left = 0, right = 0, top = 0, bottom = 0 }
+                } )
 
-			f:SetBackdropColor(.1, .1, .1, .8)
-			f:SetBackdropBorderColor(.1, .1, .1, .5)
+            f:SetBackdropColor(.1, .1, .1, .8)
+            f:SetBackdropBorderColor(.1, .1, .1, .5)
 
-			-- Show the sizing and moving frames
-			f.sizing:Show()
-			f.moving:Show()
+            -- Show the sizing and moving frames
+            f.sizing:Show()
+            f.moving:Show()
 
-			-- Frame Title
-			f.title = f:CreateFontString(nil, "OVERLAY")
-			f.title:SetPoint("BOTTOM", f, "TOP", 0, -18)
-			f.title:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 15, "OUTLINE")
-			f.title:SetText(frameTitles[framename])
+            -- Frame Title
+            f.title = f:CreateFontString(nil, "OVERLAY")
+            f.title:SetPoint("BOTTOM", f, "TOP", 0, -18)
+            f.title:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 15, "OUTLINE")
+            f.title:SetText(frameTitles[framename])
 
-			-- Size Text
-			f.width = f:CreateFontString(nil, "OVERLAY")
-			f.width:SetTextColor(.47, .55, .87, 1)
-			f.width:SetPoint("TOP", f, "BOTTOM", 0, -2)
-			f.width:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 18, "OUTLINE")
-			f.width:SetText(mfloor(f:GetWidth()+.5))
-			f.width:Hide()
+            -- Size Text
+            f.width = f:CreateFontString(nil, "OVERLAY")
+            f.width:SetTextColor(.47, .55, .87, 1)
+            f.width:SetPoint("TOP", f, "BOTTOM", 0, -2)
+            f.width:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 18, "OUTLINE")
+            f.width:SetText(mfloor(f:GetWidth()+.5))
+            f.width:Hide()
 
-			f.height = f:CreateFontString(nil, "OVERLAY")
-			f.height:SetTextColor(.47, .55, .87, 1)
-			f.height:SetPoint("LEFT", f, "RIGHT", 4, 0)
-			f.height:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 18, "OUTLINE")
-			f.height:SetText(mfloor(f:GetHeight()+.5))
-			f.height:Hide()
+            f.height = f:CreateFontString(nil, "OVERLAY")
+            f.height:SetTextColor(.47, .55, .87, 1)
+            f.height:SetPoint("LEFT", f, "RIGHT", 4, 0)
+            f.height:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 18, "OUTLINE")
+            f.height:SetText(mfloor(f:GetHeight()+.5))
+            f.height:Hide()
 
-			-- Calculate get the center of the screen from the left/top
-			local posX = mfloor(mfloor(f:GetLeft()-GetScreenWidth()/2+.5))
-			local posY = mfloor(mfloor(f:GetTop()-GetScreenHeight()/2+.5))
+            -- Calculate get the center of the screen from the left/top
+            local posX = mfloor(mfloor(f:GetLeft()-GetScreenWidth()/2+.5))
+            local posY = mfloor(mfloor(f:GetTop()-GetScreenHeight()/2+.5))
 
-			-- Position Text
-			f.position = f:CreateFontString(nil, "OVERLAY")
-			f.position:SetTextColor(1, 1, 0, 1)
-			f.position:SetPoint("BOTTOMLEFT", f, "TOPLEFT", 0, 4)
-			f.position:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 18, "OUTLINE")
-			f.position:SetText(sformat("%d, %d", posX, posY))
-			f.position:Hide()
+            -- Position Text
+            f.position = f:CreateFontString(nil, "OVERLAY")
+            f.position:SetTextColor(1, 1, 0, 1)
+            f.position:SetPoint("BOTTOMLEFT", f, "TOPLEFT", 0, 4)
+            f.position:SetFont(LSM:Fetch("font", "Condensed Bold (xCT+)"), 18, "OUTLINE")
+            f.position:SetText(sformat("%d, %d", posX, posY))
+            f.position:Hide()
 
-			f.moving.d = f:CreateTexture(nil, "OVERLAY")
-			f.moving.d:SetPoint("TOPLEFT", f, "TOPLEFT", 1, -1)
-			f.moving.d:SetPoint("TOPRIGHT", f, "TOPRIGHT", -1, -19)
-			f.moving.d:SetHeight(20)
-			f.moving.d:SetVertexColor(.3, .3, .3)
-			f.moving.d:SetTexture("Interface\\BUTTONS\\WHITE8X8.blp")
-			f.moving.d:SetAlpha(.6)
+            f.moving.d = f:CreateTexture(nil, "OVERLAY")
+            f.moving.d:SetPoint("TOPLEFT", f, "TOPLEFT", 1, -1)
+            f.moving.d:SetPoint("TOPRIGHT", f, "TOPRIGHT", -1, -19)
+            f.moving.d:SetHeight(20)
+            f.moving.d:SetVertexColor(.3, .3, .3)
+            f.moving.d:SetTexture("Interface\\BUTTONS\\WHITE8X8.blp")
+            f.moving.d:SetAlpha(.6)
 
-			f.sizing.d = f.sizing:CreateTexture("ARTWORK")
-			f.sizing.d:SetHeight(16)
-			f.sizing.d:SetWidth(16)
-			f.sizing.d:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -1, 1)
-			f.sizing.d:SetVertexColor(.3, .3, .3)
-			f.sizing.d:SetTexture("Interface\\BUTTONS\\WHITE8X8.blp")
-			f.sizing.d:SetAlpha(.6)
+            f.sizing.d = f.sizing:CreateTexture("ARTWORK")
+            f.sizing.d:SetHeight(16)
+            f.sizing.d:SetWidth(16)
+            f.sizing.d:SetPoint("BOTTOMRIGHT", f, "BOTTOMRIGHT", -1, 1)
+            f.sizing.d:SetVertexColor(.3, .3, .3)
+            f.sizing.d:SetTexture("Interface\\BUTTONS\\WHITE8X8.blp")
+            f.sizing.d:SetAlpha(.6)
 
-			-- Frame Settings
-			f:SetScript("OnEnter", Frame_MouseEnter)
-			f:SetScript("OnLeave", Frame_MouseLeave)
+            -- Frame Settings
+            f:SetScript("OnEnter", Frame_MouseEnter)
+            f:SetScript("OnLeave", Frame_MouseLeave)
 
-			-- Moving Settings
-			f.moving:EnableMouse(true)
-			f.moving:RegisterForDrag("LeftButton")
-			f.moving:SetScript("OnMouseDown", Frame_Moving_OnMouseDown)
-			f.moving:SetScript("OnMouseUp", Frame_Moving_OnMouseUp)
-			f.moving:SetScript("OnEnter", Frame_MouseEnter)
-			f.moving:SetScript("OnLeave", Frame_MouseLeave)
+            -- Moving Settings
+            f.moving:EnableMouse(true)
+            f.moving:RegisterForDrag("LeftButton")
+            f.moving:SetScript("OnMouseDown", Frame_Moving_OnMouseDown)
+            f.moving:SetScript("OnMouseUp", Frame_Moving_OnMouseUp)
+            f.moving:SetScript("OnEnter", Frame_MouseEnter)
+            f.moving:SetScript("OnLeave", Frame_MouseLeave)
 
-			-- Resizing Settings
-			f.sizing:EnableMouse(true)
-			f.sizing:RegisterForDrag("LeftButton")
-			f.sizing:SetScript("OnMouseDown", Frame_Sizing_OnMouseDown)
-			f.sizing:SetScript("OnMouseUp", Frame_Sizing_OnMouseUp)
-			f.sizing:SetScript("OnEnter", Frame_MouseEnter)
-			f.sizing:SetScript("OnLeave", Frame_MouseLeave)
+            -- Resizing Settings
+            f.sizing:EnableMouse(true)
+            f.sizing:RegisterForDrag("LeftButton")
+            f.sizing:SetScript("OnMouseDown", Frame_Sizing_OnMouseDown)
+            f.sizing:SetScript("OnMouseUp", Frame_Sizing_OnMouseUp)
+            f.sizing:SetScript("OnEnter", Frame_MouseEnter)
+            f.sizing:SetScript("OnLeave", Frame_MouseLeave)
 
-			-- TODO: Add option to adjust the number of lines for memory purposes
-			-- TODO: Show Alignment Grid
+            -- TODO: Add option to adjust the number of lines for memory purposes
+            -- TODO: Show Alignment Grid
 
-			if framename == "class" then
-				f.sizing.d:Hide()
-				f.sizing:Hide()
-			end
+            if framename == "class" then
+                f.sizing.d:Hide()
+                f.sizing:Hide()
+            end
 
-			f:SetFrameStrata("FULLSCREEN_DIALOG")
+            f:SetFrameStrata("FULLSCREEN_DIALOG")
 
-		end
-	end
+        end
+    end
 end
 
 function x.EndConfigMode()
-	x.configuring = false
-	if x.AlignGrid then x.AlignGrid:Hide() end
+    x.configuring = false
+    if x.AlignGrid then x.AlignGrid:Hide() end
 
-	for framename, settings in pairs(x.db.profile.frames) do
-		if settings.enabledFrame then
-			local f = x:GetFrame(framename)
+    for framename, settings in pairs(x.db.profile.frames) do
+        if settings.enabledFrame then
+            local f = x:GetFrame(framename)
 
-			f:SetBackdrop(nil)
+            f:SetBackdrop(nil)
 
-			-- Remove Scripts
-			f:SetScript("OnEnter", nil)
-			f:SetScript("OnLeave", nil)
+            -- Remove Scripts
+            f:SetScript("OnEnter", nil)
+            f:SetScript("OnLeave", nil)
 
-			f.moving:SetScript("OnMouseDown", nil)
-			f.moving:SetScript("OnMouseUp", nil)
-			f.moving:SetScript("OnEnter", nil)
-			f.moving:SetScript("OnLeave", nil)
+            f.moving:SetScript("OnMouseDown", nil)
+            f.moving:SetScript("OnMouseUp", nil)
+            f.moving:SetScript("OnEnter", nil)
+            f.moving:SetScript("OnLeave", nil)
 
-			f.sizing:SetScript("OnMouseDown", nil)
-			f.sizing:SetScript("OnMouseUp", nil)
-			f.sizing:SetScript("OnEnter", nil)
-			f.sizing:SetScript("OnLeave", nil)
+            f.sizing:SetScript("OnMouseDown", nil)
+            f.sizing:SetScript("OnMouseUp", nil)
+            f.sizing:SetScript("OnEnter", nil)
+            f.sizing:SetScript("OnLeave", nil)
 
-			-- Clean up visual items
-			if f.title then
-				f.title:Hide()
-				f.title = nil
-			end
+            -- Clean up visual items
+            if f.title then
+                f.title:Hide()
+                f.title = nil
+            end
 
-			if f.moving.d then
-				f.moving.d:Hide()
-				f.moving.d = nil
-			end
+            if f.moving.d then
+                f.moving.d:Hide()
+                f.moving.d = nil
+            end
 
-			if f.sizing.d then
-				f.sizing.d:Hide()
-				f.sizing.d = nil
-			end
+            if f.sizing.d then
+                f.sizing.d:Hide()
+                f.sizing.d = nil
+            end
 
-			if f.position then
-				f.position:Hide()
-				f.position = nil
-			end
+            if f.position then
+                f.position:Hide()
+                f.position = nil
+            end
 
-			if f.width then
-				f.width:Hide()
-				f.width = nil
-			end
+            if f.width then
+                f.width:Hide()
+                f.width = nil
+            end
 
-			if f.height then
-				f.height:Hide()
-				f.height = nil
-			end
+            if f.height then
+                f.height:Hide()
+                f.height = nil
+            end
 
-			f:EnableMouse(false)
+            f:EnableMouse(false)
 
-			-- Hide the sizing frame
-			f.sizing:EnableMouse(false)
-			f.sizing:Hide()
+            -- Hide the sizing frame
+            f.sizing:EnableMouse(false)
+            f.sizing:Hide()
 
-			-- Hide the moving frame
-			f.moving:EnableMouse(false)
-			f.moving:Hide()
+            -- Hide the moving frame
+            f.moving:EnableMouse(false)
+            f.moving:Hide()
 
-			-- Set the Frame Strata
-			f:SetFrameStrata(ssub(x.db.profile.frameSettings.frameStrata, 2))
-		end
-	end
+            -- Set the Frame Strata
+            f:SetFrameStrata(ssub(x.db.profile.frameSettings.frameStrata, 2))
+        end
+    end
 
-	collectgarbage()
+    collectgarbage()
 end
 
 function x.ToggleConfigMode()
-	if x.configuring then
-		return
-	else
-		-- Close the Options Dialog if it is Open
-		-- Because this could be called fromt he UI, we need to wait
-		x:HideConfigTool(true)
+    if x.configuring then
+        return
+    else
+        -- Close the Options Dialog if it is Open
+        -- Because this could be called fromt he UI, we need to wait
+        x:HideConfigTool(true)
 
-		-- Thanks Elv :)
-		GameTooltip:Hide() -- Just in case you're mouseovered something and it closes.
+        -- Thanks Elv :)
+        GameTooltip:Hide() -- Just in case you're mouseovered something and it closes.
 
-		StaticPopup_Show("XCT_PLUS_CONFIGURING")
+        StaticPopup_Show("XCT_PLUS_CONFIGURING")
 
-		if x.db.profile.frameSettings.showGrid then
-			if not x.AlignGrid then
-				x:LoadAlignmentGrid()
-			end
-			x.AlignGrid:Show()
-		end
+        if x.db.profile.frameSettings.showGrid then
+            if not x.AlignGrid then
+                x:LoadAlignmentGrid()
+            end
+            x.AlignGrid:Show()
+        end
 
-		x.StartConfigMode()
-	end
+        x.StartConfigMode()
+    end
 end
 
 function x:SaveAllFrames()
-	for framename, settings in pairs(x.db.profile.frames) do
-		local frame = x.frames[framename]
-		-- If frame is disabled, trying to calculate position will fail
-		if settings.enabledFrame then
-			local x_old, y_old, width_old, height_old = settings.X, settings.Y, settings.Width, settings.Height
+    for framename, settings in pairs(x.db.profile.frames) do
+        local frame = x.frames[framename]
+        -- If frame is disabled, trying to calculate position will fail
+        if settings.enabledFrame then
+            local x_old, y_old, width_old, height_old = settings.X, settings.Y, settings.Width, settings.Height
 
-			local width = frame:GetWidth()
-			local height = frame:GetHeight()
+            local width = frame:GetWidth()
+            local height = frame:GetHeight()
 
-			settings.Width = mfloor(width + .5)
-			settings.Height = mfloor(height + .5)
+            settings.Width = mfloor(width + .5)
+            settings.Height = mfloor(height + .5)
 
-			-- Calculate the center of the screen
-			local ResX, ResY = GetScreenWidth(), GetScreenHeight()
-			local midX, midY = ResX / 2, ResY / 2
+            -- Calculate the center of the screen
+            local ResX, ResY = GetScreenWidth(), GetScreenHeight()
+            local midX, midY = ResX / 2, ResY / 2
 
-			-- Calculate the Top/Left of a frame relative to the center
-			local left, top = mfloor(frame:GetLeft() - midX + .5), mfloor(frame:GetTop() - midY + .5)
+            -- Calculate the Top/Left of a frame relative to the center
+            local left, top = mfloor(frame:GetLeft() - midX + .5), mfloor(frame:GetTop() - midY + .5)
 
-			-- Calculate get the center of the screen from the left/top
-			settings.X = mfloor(left + (width / 2) + .5)
-			settings.Y = mfloor(top - (height / 2) + .5)
+            -- Calculate get the center of the screen from the left/top
+            settings.X = mfloor(left + (width / 2) + .5)
+            settings.Y = mfloor(top - (height / 2) + .5)
 
-		end
-	end
+        end
+    end
 end
 
 local colors = { '1', '2', '4', '8', '16', '32', '64' }
 local function GetRandomSpellColor()
-	local color = colors[math.random(7)]
-	return x.db.profile.SpellColors[color].color or x.db.profile.SpellColors[color].default
+    local color = colors[math.random(7)]
+    return x.db.profile.SpellColors[color].color or x.db.profile.SpellColors[color].default
 end
 
 -- Gets a random spell icon that is NOT an engineering cog wheel
 local function GetRandomSpellID()
-	local icon, spellID
-	repeat
-		spellID = random(100, 80000)
-		icon = C_Spell.GetSpellTexture(spellID)
-	until icon and icon ~= 136243
-	return spellID
+    local icon, spellID
+    repeat
+        spellID = random(100, 80000)
+        icon = C_Spell.GetSpellTexture(spellID)
+    until icon and icon ~= 136243
+    return spellID
 end
 
 function x.TestMoreUpdate(self, elapsed)
-	if InCombatLockdown() then
-		self:SetScript("OnUpdate", nil)
-	else
-		self.lastUpdate = self.lastUpdate + elapsed
+    if InCombatLockdown() then
+        self:SetScript("OnUpdate", nil)
+    else
+        self.lastUpdate = self.lastUpdate + elapsed
 
-		if not self.nextUpdate then
-			self.nextUpdate = random(80, 600) / 1000
-		end
+        if not self.nextUpdate then
+            self.nextUpdate = random(80, 600) / 1000
+        end
 
-		if self.nextUpdate < self.lastUpdate then
-			self.nextUpdate = nil
-			self.lastUpdate = 0
+        if self.nextUpdate < self.lastUpdate then
+            self.nextUpdate = nil
+            self.lastUpdate = 0
 
-			if self == x.frames["general"] and random(3) % 3 == 0 then
-				local output, color = "general", {random(255) / 255, random(255) / 255, random(255) / 255}
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				x:AddMessage(output, COMBAT_TEXT_LABEL, color)
-			elseif self == x.frames["outgoing"] then
-				local output, color = "outgoing", GetRandomSpellColor()
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				local message = x:Abbreviate(random(60000), "outgoing")
-				local merged, multistriked = false, 0
-				if x.db.profile.spells.enableMerger and random(3) % 3 == 0 then
-					multistriked = random(17)+1
-					merged = true
-				end
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				message = x:GetSpellTextureFormatted(
-						x.db.profile.frames["outgoing"].iconsEnabled and GetRandomSpellID() or -1,
-						message, x.db.profile.frames["outgoing"].iconsSize,
-						x.db.profile.frames["outgoing"].spacerIconsEnabled, x.db.profile.frames["outgoing"].fontJustify, nil, merged, multistriked )
-				x:AddMessage(output, message, color)
-			elseif self == x.frames["critical"] and random(2) % 2 == 0 then
-				local output, color = "critical", GetRandomSpellColor()
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				local message = x.db.profile.frames.critical.critPrefix .. x:Abbreviate(random(60000), "critical") .. x.db.profile.frames.critical.critPostfix
-				local merged, multistriked = false, 0
-				if x.db.profile.spells.enableMerger and (random(3) % 3 == 0) and (x.db.profile.spells.mergeCriticalsWithOutgoing or x.db.profile.spells.mergeCriticalsByThemselves) then
-					multistriked = random(17)+1
-					merged = true
-				end
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				message = x:GetSpellTextureFormatted(
-						x.db.profile.frames["critical"].iconsEnabled and GetRandomSpellID() or -1, -- spellID
-						message, -- message
-						x.db.profile.frames["critical"].iconsSize, -- iconSize
-						x.db.profile.frames["critical"].spacerIconsEnabled, -- showInvisibleIcon
-						x.db.profile.frames["critical"].fontJustify, -- justify
-						nil, -- strColor
-						merged, -- mergeOverride
-						multistriked -- entries
-					)
-				x:AddMessage(output, message, color)
-			elseif self == x.frames["damage"] and random(2) % 2 == 0 then
-				local output, color = "damage", {1, random(100) / 255, random(100) / 255}
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				x:AddMessage(output, "-"..x:Abbreviate(random(100000), "damage"), color)
-			elseif self == x.frames["healing"] and random(2) % 2 == 0 then
-				local output, color = "healing", {.1, ((random(3) + 1) * 63) / 255, .1}
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				if COMBAT_TEXT_SHOW_FRIENDLY_NAMES == "1" then
-					local message = UnitName("player")
-					local realm = ""
-					if x.db.profile.frames["healing"].enableRealmNames then realm = "-"..GetRealmName() end
-					if x.db.profile.frames["healing"].enableClassNames then
-						message = sformat("|c%s%s%s|r", RAID_CLASS_COLORS[select(2,UnitClass("player"))].colorStr, message, realm)
-					end
-					if x.db.profile.spells.mergeHealing and random(2) % 2 == 0 then
-						message = sformat("%s |cffFFFF00x%s|r", message, random(17)+1)
-					end
-					x:AddMessage(output, "+"..x:Abbreviate(random(90000),"healing") .. " "..message, color)
-				else
-					x:AddMessage(output, "+"..x:Abbreviate(random(90000),"healing"), color)
-				end
-			elseif self == x.frames["power"] and random(4) % 4 == 0 then
-				local output = "power"
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				local _, powerToken = UnitPowerType("player")
-				local color = { PowerBarColor[powerToken].r, PowerBarColor[powerToken].g, PowerBarColor[powerToken].b }
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				x:AddMessage(output, "+"..x:Abbreviate(random(5000),"power").." ".._G[powerToken], color)
-			elseif self == x.frames["class"] and random(4) % 4 == 0 then
-				if not x.db.profile.frames["class"].enabledFrame then x:Clear("class") return end
-				if not self.testCombo then
-					self.testCombo = 0
-				end
-				self.testCombo = self.testCombo + 1
-				if self.testCombo > 8 then
-					self.testCombo = 1
-				end
-				local color = {1, .82, 0}
-				if x.db.profile.frames["class"].customColor then
-					color = x.db.profile.frames["class"].fontColor
-				end
-				x:AddMessage("class", tostring(self.testCombo), color)
-			elseif self == x.frames["procs"] and random(8) % 8 == 0 then
-				local output = "procs"
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				local color = {1, 1, 0}
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				x:AddMessage(output, ERR_SPELL_COOLDOWN, color)
-			elseif self == x.frames["loot"] and random(8) % 8 == 0 then
-				local output = "loot"
-				if not x.db.profile.frames[output].enabledFrame then
-					x:Clear(output)
-					if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
-				end
-				local color = {1, 1, 0}
-				if x.db.profile.frames[output].customColor then
-					color = x.db.profile.frames[output].fontColor
-				end
-				if x.db.profile.frames[output].colorBlindMoney then
-					local g, s, c, message = random(100) % 10 ~= 0 and random(100) or nil, random(100) % 10 ~= 0 and random(100) or nil, random(100) % 10 ~= 0 and random(100) or nil, ""
-					if g then message = tostring(g).."|cffFFD700g|r" end
-					if s then if g then message = message .. " " .. tostring(s).."|cffC0C0C0s|r" else message = message .. tostring(s).."|cffC0C0C0s|r" end end
-					if c then if s or g then message = message .. " " .. tostring(c).."|cffB87333c|r" else message = message .. tostring(c).."|cffB87333c|r" end end
-					if not g and not s and not c then return end
-					x:AddMessage(output, MONEY .. ": " .. message, color)
-				else
-					x:AddMessage(output, MONEY .. ": " .. C_CurrencyInfo.GetCoinTextureString(random(1000000)), color)
-				end
-			end
-		end
-	end
+            if self == x.frames["general"] and random(3) % 3 == 0 then
+                local output, color = "general", {random(255) / 255, random(255) / 255, random(255) / 255}
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                x:AddMessage(output, COMBAT_TEXT_LABEL, color)
+            elseif self == x.frames["outgoing"] then
+                local output, color = "outgoing", GetRandomSpellColor()
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                local message = x:Abbreviate(random(60000), "outgoing")
+                local merged, multistriked = false, 0
+                if x.db.profile.spells.enableMerger and random(3) % 3 == 0 then
+                    multistriked = random(17)+1
+                    merged = true
+                end
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                message = x:GetSpellTextureFormatted(
+                        x.db.profile.frames["outgoing"].iconsEnabled and GetRandomSpellID() or -1,
+                        message, x.db.profile.frames["outgoing"].iconsSize,
+                        x.db.profile.frames["outgoing"].spacerIconsEnabled, x.db.profile.frames["outgoing"].fontJustify, nil, merged, multistriked )
+                x:AddMessage(output, message, color)
+            elseif self == x.frames["critical"] and random(2) % 2 == 0 then
+                local output, color = "critical", GetRandomSpellColor()
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                local message = x.db.profile.frames.critical.critPrefix .. x:Abbreviate(random(60000), "critical") .. x.db.profile.frames.critical.critPostfix
+                local merged, multistriked = false, 0
+                if x.db.profile.spells.enableMerger and (random(3) % 3 == 0) and (x.db.profile.spells.mergeCriticalsWithOutgoing or x.db.profile.spells.mergeCriticalsByThemselves) then
+                    multistriked = random(17)+1
+                    merged = true
+                end
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                message = x:GetSpellTextureFormatted(
+                        x.db.profile.frames["critical"].iconsEnabled and GetRandomSpellID() or -1, -- spellID
+                        message, -- message
+                        x.db.profile.frames["critical"].iconsSize, -- iconSize
+                        x.db.profile.frames["critical"].spacerIconsEnabled, -- showInvisibleIcon
+                        x.db.profile.frames["critical"].fontJustify, -- justify
+                        nil, -- strColor
+                        merged, -- mergeOverride
+                        multistriked -- entries
+                    )
+                x:AddMessage(output, message, color)
+            elseif self == x.frames["damage"] and random(2) % 2 == 0 then
+                local output, color = "damage", {1, random(100) / 255, random(100) / 255}
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                x:AddMessage(output, "-"..x:Abbreviate(random(100000), "damage"), color)
+            elseif self == x.frames["healing"] and random(2) % 2 == 0 then
+                local output, color = "healing", {.1, ((random(3) + 1) * 63) / 255, .1}
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                if COMBAT_TEXT_SHOW_FRIENDLY_NAMES == "1" then
+                    local message = UnitName("player")
+                    local realm = ""
+                    if x.db.profile.frames["healing"].enableRealmNames then realm = "-"..GetRealmName() end
+                    if x.db.profile.frames["healing"].enableClassNames then
+                        message = sformat("|c%s%s%s|r", RAID_CLASS_COLORS[select(2,UnitClass("player"))].colorStr, message, realm)
+                    end
+                    if x.db.profile.spells.mergeHealing and random(2) % 2 == 0 then
+                        message = sformat("%s |cffFFFF00x%s|r", message, random(17)+1)
+                    end
+                    x:AddMessage(output, "+"..x:Abbreviate(random(90000),"healing") .. " "..message, color)
+                else
+                    x:AddMessage(output, "+"..x:Abbreviate(random(90000),"healing"), color)
+                end
+            elseif self == x.frames["power"] and random(4) % 4 == 0 then
+                local output = "power"
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                local _, powerToken = UnitPowerType("player")
+                local color = { PowerBarColor[powerToken].r, PowerBarColor[powerToken].g, PowerBarColor[powerToken].b }
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                x:AddMessage(output, "+"..x:Abbreviate(random(5000),"power").." ".._G[powerToken], color)
+            elseif self == x.frames["class"] and random(4) % 4 == 0 then
+                if not x.db.profile.frames["class"].enabledFrame then x:Clear("class") return end
+                if not self.testCombo then
+                    self.testCombo = 0
+                end
+                self.testCombo = self.testCombo + 1
+                if self.testCombo > 8 then
+                    self.testCombo = 1
+                end
+                local color = {1, .82, 0}
+                if x.db.profile.frames["class"].customColor then
+                    color = x.db.profile.frames["class"].fontColor
+                end
+                x:AddMessage("class", tostring(self.testCombo), color)
+            elseif self == x.frames["procs"] and random(8) % 8 == 0 then
+                local output = "procs"
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                local color = {1, 1, 0}
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                x:AddMessage(output, ERR_SPELL_COOLDOWN, color)
+            elseif self == x.frames["loot"] and random(8) % 8 == 0 then
+                local output = "loot"
+                if not x.db.profile.frames[output].enabledFrame then
+                    x:Clear(output)
+                    if x.db.profile.frames[output].secondaryFrame ~= 0 then output = frameIndex[x.db.profile.frames[output].secondaryFrame] else return end
+                end
+                local color = {1, 1, 0}
+                if x.db.profile.frames[output].customColor then
+                    color = x.db.profile.frames[output].fontColor
+                end
+                if x.db.profile.frames[output].colorBlindMoney then
+                    local g, s, c, message = random(100) % 10 ~= 0 and random(100) or nil, random(100) % 10 ~= 0 and random(100) or nil, random(100) % 10 ~= 0 and random(100) or nil, ""
+                    if g then message = tostring(g).."|cffFFD700g|r" end
+                    if s then if g then message = message .. " " .. tostring(s).."|cffC0C0C0s|r" else message = message .. tostring(s).."|cffC0C0C0s|r" end end
+                    if c then if s or g then message = message .. " " .. tostring(c).."|cffB87333c|r" else message = message .. tostring(c).."|cffB87333c|r" end end
+                    if not g and not s and not c then return end
+                    x:AddMessage(output, MONEY .. ": " .. message, color)
+                else
+                    x:AddMessage(output, MONEY .. ": " .. C_CurrencyInfo.GetCoinTextureString(random(1000000)), color)
+                end
+            end
+        end
+    end
 end
 
 function x.ToggleTestMode(hidePopup)
-	if x.configuring then
-		return
-	else
-		if x.testing then
-			x.EndTestMode()
-		else
-			x.testing = true
+    if x.configuring then
+        return
+    else
+        if x.testing then
+            x.EndTestMode()
+        else
+            x.testing = true
 
-			-- Start the Test more
-			for framename, settings in pairs(x.db.profile.frames) do
-				local frame = x:GetFrame(framename)
-				frame.nextUpdate = nil
-				frame.lastUpdate = 0
-				frame:SetScript("OnUpdate", x.TestMoreUpdate)
-			end
+            -- Start the Test more
+            for framename, settings in pairs(x.db.profile.frames) do
+                local frame = x:GetFrame(framename)
+                frame.nextUpdate = nil
+                frame.lastUpdate = 0
+                frame:SetScript("OnUpdate", x.TestMoreUpdate)
+            end
 
-			-- Test more Popup
-			-- Because this could be called fromt he UI, we need to wait
-			x:HideConfigTool(true)
+            -- Test more Popup
+            -- Because this could be called fromt he UI, we need to wait
+            x:HideConfigTool(true)
 
-			if type(hidePopup) == "boolean" and hidePopup then
-				return
-			else
-				StaticPopup_Show("XCT_PLUS_TESTMODE")
-			end
-		end
-	end
+            if type(hidePopup) == "boolean" and hidePopup then
+                return
+            else
+                StaticPopup_Show("XCT_PLUS_TESTMODE")
+            end
+        end
+    end
 end
 
 function x.EndTestMode()
-	x.testing = false
+    x.testing = false
 
-	-- Stop the Test more
-	for framename, settings in pairs(x.db.profile.frames) do
-		local frame = x:GetFrame(framename)
-		frame:SetScript("OnUpdate", nil)
-		frame:Clear()
-	end
+    -- Stop the Test more
+    for framename, settings in pairs(x.db.profile.frames) do
+        local frame = x:GetFrame(framename)
+        frame:SetScript("OnUpdate", nil)
+        frame:Clear()
+    end
 
-	StaticPopup_Hide("XCT_PLUS_TESTMODE")
+    StaticPopup_Hide("XCT_PLUS_TESTMODE")
 end
 
 function x.RestoreAllDefaults()
-	LibStub("AceConfigDialog-3.0"):Close(ADDON_NAME)
-	GameTooltip:Hide()
-	StaticPopup_Show("XCT_PLUS_RESET_SETTINGS")
+    LibStub("AceConfigDialog-3.0"):Close(ADDON_NAME)
+    GameTooltip:Hide()
+    StaticPopup_Show("XCT_PLUS_RESET_SETTINGS")
 end
 
 -- Popups
 StaticPopupDialogs["XCT_PLUS_CONFIGURING"] = {
-	text			= "Configuring xCT+\nType: |cffFF0000/xct lock|r to save changes",
-	timeout			= 0,
-	whileDead		= 1,
+    text            = "Configuring xCT+\nType: |cffFF0000/xct lock|r to save changes",
+    timeout            = 0,
+    whileDead        = 1,
 
-	button1			= SAVE_CHANGES,
-	button2			= CANCEL,
-	OnAccept		= function() x:SaveAllFrames(); x.EndConfigMode(); x:ShowConfigTool() print("|cffFF0000x|r|cffFFFF00CT+|r  Frames have been saved. Please fasten your seat belts.") end,
-	OnCancel		= function() x:UpdateFrames(); x.EndConfigMode(); x:ShowConfigTool() end,
-	hideOnEscape	= false,
+    button1            = SAVE_CHANGES,
+    button2            = CANCEL,
+    OnAccept        = function() x:SaveAllFrames(); x.EndConfigMode(); x:ShowConfigTool() print("|cffFF0000x|r|cffFFFF00CT+|r  Frames have been saved. Please fasten your seat belts.") end,
+    OnCancel        = function() x:UpdateFrames(); x.EndConfigMode(); x:ShowConfigTool() end,
+    hideOnEscape    = false,
 
-	-- Taint work around
-	preferredIndex	= 3,
+    -- Taint work around
+    preferredIndex    = 3,
 }
 
 StaticPopupDialogs["XCT_PLUS_TESTMODE"] = {
-	text			= "xCT+ Test Mode",
-	timeout			= 0,
-	whileDead		= 1,
+    text            = "xCT+ Test Mode",
+    timeout            = 0,
+    whileDead        = 1,
 
-	button1			= "Stop",
-	OnAccept		= function() x.EndTestMode(); x:ShowConfigTool() end,
-	hideOnEscape	= true,
+    button1            = "Stop",
+    OnAccept        = function() x.EndTestMode(); x:ShowConfigTool() end,
+    hideOnEscape    = true,
 
-	-- Taint work around
-	preferredIndex	= 3,
+    -- Taint work around
+    preferredIndex    = 3,
 }
 
 StaticPopupDialogs["XCT_PLUS_RESET_SETTINGS"] = {
-	text			= "Are your certain you want to erase |cffFF0000ALL|r your xCT+ settings?",
-	timeout			= 0,
-	whileDead		= 1,
+    text            = "Are your certain you want to erase |cffFF0000ALL|r your xCT+ settings?",
+    timeout            = 0,
+    whileDead        = 1,
 
-	button1			= "|cffFF0000ERASE ALL!!|r",
-	button2			= CANCEL,
-	OnAccept		= function() xCTSavedDB = nil; ReloadUI() end,
-	OnCancel		= function() x:ShowConfigTool() end,
-	hideOnEscape	= true,
+    button1            = "|cffFF0000ERASE ALL!!|r",
+    button2            = CANCEL,
+    OnAccept        = function() xCTSavedDB = nil; ReloadUI() end,
+    OnCancel        = function() x:ShowConfigTool() end,
+    hideOnEscape    = true,
 
-	-- Taint work around
-	preferredIndex	= 3,
+    -- Taint work around
+    preferredIndex    = 3,
 }
 
 StaticPopupDialogs["XCT_PLUS_HIDE_IN_COMBAT"] = {
-	text			= "|cffFFFF00Disable the|r |cff798BDDHide Config in Combat|r|cffFFFF00 feature?|r\n\n\n|cffFF0000WARNING:|r By disabling this protection you risk |cffFF8000tainting|r your UI. In some cases, you will need to type: '|cff798BDD/reload|r' in order to change |cff10FF40glyphs|r or |cff10FF40talents|r and to place |cff10FF40world markers|r.\n",
-	timeout			= 0,
-	whileDead		= 1,
+    text            = "|cffFFFF00Disable the|r |cff798BDDHide Config in Combat|r|cffFFFF00 feature?|r\n\n\n|cffFF0000WARNING:|r By disabling this protection you risk |cffFF8000tainting|r your UI. In some cases, you will need to type: '|cff798BDD/reload|r' in order to change |cff10FF40glyphs|r or |cff10FF40talents|r and to place |cff10FF40world markers|r.\n",
+    timeout            = 0,
+    whileDead        = 1,
 
-	button1			= CONTINUE,
-	button2			= REVERT,
-	OnAccept		= x.noop,
-	OnCancel		= function() x.db.profile.hideConfig = true; x:RefreshConfig() end,
+    button1            = CONTINUE,
+    button2            = REVERT,
+    OnAccept        = x.noop,
+    OnCancel        = function() x.db.profile.hideConfig = true; x:RefreshConfig() end,
 
-	-- Taint work around
-	preferredIndex	= 3,
+    -- Taint work around
+    preferredIndex    = 3,
 }
 
 StaticPopupDialogs["XCT_PLUS_DB_CLEANUP_1"] = {
-	text			  = "|cff798BDDxCT+ Spring Cleaning|r\n\nHello, |cffFFFF00xCT|r|cffFF0000+|r needed to cleanup some |cffFF0000old or removed spell entries|r from the spam merger. |cffFFFF00Those settings needed to be reset|r. The rest of your profile settings |cff22FF44remains the same|r.\n\nSorry for this inconvenience.\n\n",
-	timeout			= 0,
-	whileDead		= 1,
+    text              = "|cff798BDDxCT+ Spring Cleaning|r\n\nHello, |cffFFFF00xCT|r|cffFF0000+|r needed to cleanup some |cffFF0000old or removed spell entries|r from the spam merger. |cffFFFF00Those settings needed to be reset|r. The rest of your profile settings |cff22FF44remains the same|r.\n\nSorry for this inconvenience.\n\n",
+    timeout            = 0,
+    whileDead        = 1,
 
-	button1			= OKAY.."!",
-	button2			= "Don't Show Again",
-	hideOnEscape	= true,
+    button1            = OKAY.."!",
+    button2            = "Don't Show Again",
+    hideOnEscape    = true,
 
-	OnCancel		= function() x.db.global.dontShowDBCleaning = true end,
+    OnCancel        = function() x.db.global.dontShowDBCleaning = true end,
 
-	-- Taint work around
-	preferredIndex	= 3,
+    -- Taint work around
+    preferredIndex    = 3,
 }
 
 StaticPopupDialogs["XCT_PLUS_FORCE_CVAR_UPDATE"] = {
-	text			= "|cff798BDDxCT+|r performed an action that requires it to update some |cffFFFF00Combat Text|r related |cffFF8000CVars|r. It is |cff20DD40highly recommened|r you reload your UI before changing any more settings.",
-	timeout			= 0,
-	whileDead		= 1,
+    text            = "|cff798BDDxCT+|r performed an action that requires it to update some |cffFFFF00Combat Text|r related |cffFF8000CVars|r. It is |cff20DD40highly recommened|r you reload your UI before changing any more settings.",
+    timeout            = 0,
+    whileDead        = 1,
 
-	button1			= "Later",
-	button2			= "Reload UI Now",
-	OnAccept		= x.noop,
-	OnCancel		= ReloadUI,
+    button1            = "Later",
+    button2            = "Reload UI Now",
+    OnAccept        = x.noop,
+    OnCancel        = ReloadUI,
 
-	-- Taint work around
-	preferredIndex	= 3,
+    -- Taint work around
+    preferredIndex    = 3,
 }
 
 StaticPopupDialogs["XCT_PLUS_SUGGEST_MULTISTRIKE_OFF"] = {
-	text            = ""
+    text            = ""
 
 }
 
 StaticPopupDialogs["XCT_PLUS_DB_CLEANUP_2"] = {
-	text			= "|cffD7DF23xCT+ Legion Clean Up|r\n\nHello Again,\n\n I am sorry to inform you that |cffFFFF00xCT|r|cffFF0000+|r needs to\n\n|cffFF0000COMPLETELY RESET YOUR PROFILE|r\n\n back to the original defaults. \n\nI know this may significantly inconvenience many of you, but after much deliberation, the profile reset is the only way to properly prepare your profile for Legion.\n\n|cffFFFF00We will need to |r|cff798BDDReload Your UI|r|cffFFFF00 after we |cff798BDDReset Your Profile|r|cffFFFF00. Press the button below to continue...\n\n|cffaaaaaa(Your saved vars have NOT been reset yet and you may revert to an older version of xCT+ at this time by simply exiting the game, but that is not recommended)|r",
-	timeout			= 0,
-	whileDead		= 1,
+    text            = "|cffD7DF23xCT+ Legion Clean Up|r\n\nHello Again,\n\n I am sorry to inform you that |cffFFFF00xCT|r|cffFF0000+|r needs to\n\n|cffFF0000COMPLETELY RESET YOUR PROFILE|r\n\n back to the original defaults. \n\nI know this may significantly inconvenience many of you, but after much deliberation, the profile reset is the only way to properly prepare your profile for Legion.\n\n|cffFFFF00We will need to |r|cff798BDDReload Your UI|r|cffFFFF00 after we |cff798BDDReset Your Profile|r|cffFFFF00. Press the button below to continue...\n\n|cffaaaaaa(Your saved vars have NOT been reset yet and you may revert to an older version of xCT+ at this time by simply exiting the game, but that is not recommended)|r",
+    timeout            = 0,
+    whileDead        = 1,
 
-	button1			= "Exit WoW",
-	button2			= "Reset Profile and Reload UI",
+    button1            = "Exit WoW",
+    button2            = "Reset Profile and Reload UI",
 
-	OnAccept		= Quit,
-	OnCancel		= function () print("Resetting UI"); x.CleanUpForLegion() end,
+    OnAccept        = Quit,
+    OnCancel        = function () print("Resetting UI"); x.CleanUpForLegion() end,
 
-	-- Taint work around
-	preferredIndex	= 3,
+    -- Taint work around
+    preferredIndex    = 3,
 }

--- a/modules/frames.lua
+++ b/modules/frames.lua
@@ -696,10 +696,16 @@ do
             end
 
             -- Add Icons
+            local iconSize = settings.iconsEnabled and settings.iconsSize or -1
+            if frameName == 'damage' and stack[idIndex] == 6603 and not x:ShowIncomingAutoAttackIcons() then
+                -- Disable the auto attack icon for the incoming damage frame
+                iconSize = -1
+            end
+
             message = x:GetSpellTextureFormatted(
                 stack[idIndex],
                 message,
-                settings.iconsEnabled and settings.iconsSize or -1,
+                iconSize,
                 settings.spacerIconsEnabled,
                 settings.fontJustify,
                 strColor,

--- a/modules/frames.lua
+++ b/modules/frames.lua
@@ -483,18 +483,14 @@ local spam_format = "%s%s x%s"
 
 -- =====================================================
 -- AddOn:AddSpamMessage(
---        framename,        [string]              - the framename
---        mergeID,        [number or string]      - idenitity items to merge, if number
---                                                then it HAS TO BE the valid spell ID
---        message,        [number or string]      - the pre-formatted message to be sent,
---                                                if its not a number, then only the
---                                                first 'message' value that is sent
---                                                this mergeID will be used.
---        colorname,        [string or table]     - the name of the color OR a table
---                                                containing the color (e.g.
---                                                colorname={1,2,3} -- r=1, b=2, g=3)
---    )
---        Sends a message to the framename specified.
+--     framename, [string]              - the framename
+--     mergeID,   [number or string]    - identity items to merge, if number then it HAS TO BE the valid spell ID
+--     message,   [number or string]    - the pre-formatted message to be sent, if its not a number, then only the
+--                                        first 'message' value that is sent this mergeID will be used.
+--     colorname, [string or table]     - the name of the color OR a table containing the color (e.g.
+--                                        colorname={1,2,3} -- r=1, b=2, g=3)
+-- )
+-- Sends a message to the framename specified.
 -- =====================================================
 function x:AddSpamMessage(framename, mergeID, message, colorname, interval, prep, ...)
 
@@ -700,22 +696,16 @@ do
             end
 
             -- Add Icons
-            if frameName == "outgoing" or frameName == "critical" then
-                message = x:GetSpellTextureFormatted( stack[idIndex],
-                                                      message,
-                                                      settings.iconsEnabled and settings.iconsSize or -1,
-                                                      settings.spacerIconsEnabled,
-                                                      settings.fontJustify,
-                                                      strColor,
-                                                      true, -- Merge Override = true
-                                                      item.mergedCount )
-            elseif frameName == "healing" or frameName == "damage" then
-                if item.mergedCount > 1 then
-                    message = sformat(" |T"..x.BLANK_ICON..":%d:%d:0:0:64:64:5:59:5:59|t %s |cff%sx%s|r", settings.iconsSize, settings.iconsSize, message, strColor, item.mergedCount)
-                else
-                    message = sformat(" |T"..x.BLANK_ICON..":%d:%d:0:0:64:64:5:59:5:59|t %s", settings.iconsSize, settings.iconsSize, message)
-                end
-            end
+            message = x:GetSpellTextureFormatted(
+                stack[idIndex],
+                message,
+                settings.iconsEnabled and settings.iconsSize or -1,
+                settings.spacerIconsEnabled,
+                settings.fontJustify,
+                strColor,
+                true, -- Merge Override = true
+                item.mergedCount
+            )
 
             x:AddMessage(frameIndex[index], message, item.color)
 

--- a/modules/frames.lua
+++ b/modules/frames.lua
@@ -679,7 +679,7 @@ do
             -- Show healer name (colored)
             elseif frameName == "healing" then
                 --format_mergeCount = "%s |cffFFFF00x%s|r"
-                local strColor = "ffff00"
+                strColor = "ffff00"
 
                 if settings.names[item.sourceController].nameType == 1 then
                     fakeArgs.sourceName = stack[idIndex]

--- a/xCT+.toc
+++ b/xCT+.toc
@@ -1,4 +1,4 @@
-## Interface: 110005
+## Interface: 110007
 ## Title: xCT+
 ## Notes: An Add-On that can out-perform or enhance the default Floating Combat Text!
 ## Author: Dandruff-Stormreaver US

--- a/xCT+.toc
+++ b/xCT+.toc
@@ -1,4 +1,4 @@
-## Interface: 110000
+## Interface: 110005
 ## Title: xCT+
 ## Notes: An Add-On that can out-perform or enhance the default Floating Combat Text!
 ## Author: Dandruff-Stormreaver US


### PR DESCRIPTION
The spam merger wont show spell icons for incoming damage.

This was explicitly disabled, idk why ... but Ive enabled it.

I order for me to debug properly I had to do some code style cleanup - Ive replaced all tabs with 4 spaces in the 2 files Ive worked on.


Fixes #249 and #248 