### PR TITLE
Fixed non toggleable control "Show Auto Attacks" in "Outgoing Damage (Criticals)" section

### DIFF
--- a/xCT+/modules/options.lua
+++ b/xCT+/modules/options.lua
@@ -124,7 +124,7 @@ end
 
 -- Frame "Outgoing Damage (Criticals)"
 function x:Options_Critical_ShowAutoAttack()
-    return x.db.profile.frames.outgoing.enableAutoAttack_Critical
+    return x.db.profile.frames.critical.enableAutoAttack_Critical
 end
 
 function x:Options_Critical_PrefixAutoAttack()


### PR DESCRIPTION
Option `enableAutoAttack_Critical` was mistakenly put in `outgoing` instead of `critical` config section. Because of that players were unable to change this option and it always was true by default.