### PR TITLE
Changed target frame for merged criticals hits

### DIFF
--- a/xCT+/modules/combattext.lua
+++ b/xCT+/modules/combattext.lua
@@ -510,7 +510,7 @@ EventHandlers.OutgoingHealing = function(args)
                 return
             elseif x:Options_SpamMerger_MergeCriticalsWithOutgoing() then
                 x:AddSpamMessage(
-                    "outgoing_healing",
+                    "outgoing_criticals",
                     args.spellId,
                     amount,
                     outputColor,
@@ -527,7 +527,7 @@ EventHandlers.OutgoingHealing = function(args)
                 )
             elseif x:Options_SpamMerger_HideMergedCriticals() then
                 x:AddSpamMessage(
-                    "outgoing_healing",
+                    "outgoing_criticals",
                     args.spellId,
                     amount,
                     outputColor,

--- a/xCT+/modules/combattext.lua
+++ b/xCT+/modules/combattext.lua
@@ -510,7 +510,7 @@ EventHandlers.OutgoingHealing = function(args)
                 return
             elseif x:Options_SpamMerger_MergeCriticalsWithOutgoing() then
                 x:AddSpamMessage(
-                    "outgoing_criticals",
+                    "critical",
                     args.spellId,
                     amount,
                     outputColor,
@@ -527,7 +527,7 @@ EventHandlers.OutgoingHealing = function(args)
                 )
             elseif x:Options_SpamMerger_HideMergedCriticals() then
                 x:AddSpamMessage(
-                    "outgoing_criticals",
+                    "critical",
                     args.spellId,
                     amount,
                     outputColor,


### PR DESCRIPTION
For some reason merged criticals hits were displayed only in `outgoing_healing`. I've changed target frame to `critical`.